### PR TITLE
feat: #40/ 닉네임 수정 구현

### DIFF
--- a/src/apis/member/memberApi.ts
+++ b/src/apis/member/memberApi.ts
@@ -14,7 +14,7 @@ class MemberApi {
   };
 
   patchNickname = async (nickname: string): Promise<void> => {
-    return await instance.patch(`/member/info`, {
+    return await instance.patch(`/member/nickname`, {
       nickname,
     });
   };

--- a/src/hooks/mutations/usePatchProfile.ts
+++ b/src/hooks/mutations/usePatchProfile.ts
@@ -1,0 +1,19 @@
+import memberApi from '@apis/member/memberApi';
+import { useRouter } from 'next/router';
+import { queryClient } from 'pages/_app';
+import { useMutation } from 'react-query';
+
+export const usePatchProfile = () => {
+  const router = useRouter();
+  return useMutation<void, void, string, unknown>(
+    (nickname: string) => memberApi.patchNickname(nickname),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['useGetProfile'],
+        });
+        router.replace('/my');
+      },
+    },
+  );
+};

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+const useDebounce = (callback: () => Promise<void>, delay: number) => {
+  useEffect(() => {
+    const timer = setTimeout(callback, delay);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [callback, delay]);
+};
+
+export default useDebounce;

--- a/src/pages/my/edit.tsx
+++ b/src/pages/my/edit.tsx
@@ -40,11 +40,10 @@ const Edit = () => {
     formState: { errors },
   } = useForm<FormValue>({ mode: 'onChange' });
   const [isValidate, setIsValidate] = useState<boolean>(true);
-  const [value, setValue] = useState<string>('');
   const { mutate: editProfile } = usePatchProfile();
-  const nickname = watch('nickname');
+  const value = watch('nickname');
   const validateNickname = async () => {
-    if (nickname?.length >= 2 && nickname?.length <= 10 && !!!errors.nickname) {
+    if (value?.length >= 2 && value?.length <= 10 && !!!errors.nickname) {
       const { status } = await memberApi.getNicknameValidate(value);
       if (status || value.length === 0) {
         setIsValidate(false);
@@ -72,11 +71,10 @@ const Edit = () => {
                 value: /^[가-힣A-Za-z0-9]{2,10}$/g,
                 message: '최소 2자 ~ 최대 10자 까지 입력 가능합니다.',
               },
-              onChange: (e) => setValue(e.target.value),
             })}
             maxLength={10}
             type="text"
-            className={nickname ? 'border-text-strong' : 'border-text-assitive'}
+            className={value ? 'border-text-strong' : 'border-text-assitive'}
           />
           <EditButton
             disabled={isValidate || !!errors.nickname}


### PR DESCRIPTION
## 🛠 작업 내용

close #40 

- 닉네임 수정 커스텀 훅을 생성했습니다.
- debounce를 통해 타이핑이 끝나고 0.4초 후 닉네임 중복확인 api가 동작합니다.
- 닉네임 수정 인풋의 패턴을 추가하여 패턴에 해당하지 않으면 버튼이 disabled 됩니다.
- 닉네임의 패턴도 일치하고 중복되지 않은 경우에만 버튼이 활성화됩니다.

## 📸 스크린샷 or GIF


https://user-images.githubusercontent.com/79186378/230785956-40f2f9fb-28f6-46ea-89b2-773ae2777f6f.mov


