### PR TITLE
feat: #55/ 비로그인 유저 로직 구현

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -31,7 +31,6 @@ instance.interceptors.response.use(
   async (error) => {
     const { config: originalRequest, response } = error;
     const { data } = response;
-    console.log(data.error_code);
     const UnAuthorizeError = data.error_code === '100';
     const InvalidTokenError = data.error_code === '101';
     const ExpiredTokenError = data.error_code === '102';

--- a/src/components/common/Map.tsx
+++ b/src/components/common/Map.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, SetStateAction, Dispatch } from 'react';
-
+import { getSelectedImg, getDefaultImg } from '@utils/getImgSrc';
 type MapProps = {
   shopInfo: Shop[] | undefined;
   isLoaded: boolean;
@@ -21,32 +21,6 @@ const Map = ({
 }: MapProps) => {
   const mapContainer = useRef<HTMLDivElement>(null);
   const [markers, setMarkers] = useState<any[]>([]);
-
-  const getSelectedImg = (name) => {
-    const src = name.includes('인생네컷')
-      ? '/svg/marker_select_pink.svg'
-      : name.includes('하루필름')
-      ? '/svg/marker_select_gray.svg'
-      : name.includes('포토이즘')
-      ? '/svg/marker_select_blue.svg'
-      : name.includes('포토그레이')
-      ? '/svg/marker_select_black.svg'
-      : '/svg/marker_select_white.svg';
-    return src;
-  };
-
-  const getDefaultImg = (name) => {
-    const src = name.includes('인생네컷')
-      ? '/svg/marker_pink.svg'
-      : name.includes('하루필름')
-      ? '/svg/marker_gray.svg'
-      : name.includes('포토이즘')
-      ? '/svg/marker_blue.svg'
-      : name.includes('포토그레이')
-      ? '/svg/marker_black.svg'
-      : '/svg/marker_white.svg';
-    return src;
-  };
 
   useEffect(() => {
     if (isLoaded) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,12 @@
-import Layout from '@components/layout/Layout';
 import '@styles/globals.css';
-import { NextPage } from 'next';
 import type { AppProps } from 'next/app';
+import { getLocalStorage } from '@utils/localStorage';
+import { NextPage } from 'next';
+import { useRouter } from 'next/router';
 import { ReactElement, ReactNode } from 'react';
 import { Hydrate, QueryClient, QueryClientProvider } from 'react-query';
+import Layout from '@components/layout/Layout';
+import Modal from '@components/common/Modal';
 
 declare global {
   interface Window {
@@ -22,6 +25,25 @@ type AppPropsWithLayout = AppProps & {
 const queryClient = new QueryClient();
 
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
+  const router = useRouter();
+  const loginRequiredPages = ['/my', '/wish'];
+  if (
+    loginRequiredPages.includes(router.pathname) &&
+    !getLocalStorage('@token')
+  ) {
+    return (
+      <Layout>
+        <Modal
+          isModal={true}
+          isKakao={true}
+          title="로그인 상태가 아니에요!"
+          message="해당 페이지는 카카오톡 로그인을 하셔야 이용가능한 페이지에요. 로그인 하시겠어요?"
+          left="아니요"
+          leftEvent={() => router.back()}
+        />
+      </Layout>
+    );
+  }
   const getLayout = Component.getLayout ?? ((page) => <Layout>{page}</Layout>);
   return getLayout(
     <QueryClientProvider client={queryClient}>

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -7,30 +7,6 @@ import SettingList from '@components/my/SettingList';
 import { useGetProfile } from '@hooks/queries/useGetProfile';
 import { useRouter } from 'next/router';
 
-const GreetingBox = tw.div`
-flex h-[60px] justify-between px-[16px] mt-[62px]
-`;
-
-const Greeting = tw.div`
-flex items-center text-title1 font-normal
-`;
-
-const SettingBox = tw.div`
-flex cursor-pointer rounded-xl border bg-bg-tertiary p-1
-`;
-
-const ItemsContainer = tw.div`
-flex w-full justify-between px-[16px] py-[24px]
-`;
-
-const ListsContainer = tw.div`
-flex cursor-pointer flex-col px-[16px] text-body2 font-normal
-`;
-
-const DivisionBar = tw.div`
-h-[4px] w-full bg-bg-primary
-`;
-
 export type SettingListsProps = {
   id: number;
   text: string;
@@ -89,5 +65,29 @@ const My = () => {
     </PageLayout>
   );
 };
+
+const GreetingBox = tw.div`
+flex h-[60px] justify-between px-[16px] mt-[62px]
+`;
+
+const Greeting = tw.div`
+flex items-center text-title1 font-normal
+`;
+
+const SettingBox = tw.div`
+flex cursor-pointer rounded-xl border bg-bg-tertiary p-1
+`;
+
+const ItemsContainer = tw.div`
+flex w-full justify-between px-[16px] py-[24px]
+`;
+
+const ListsContainer = tw.div`
+flex cursor-pointer flex-col px-[16px] text-body2 font-normal
+`;
+
+const DivisionBar = tw.div`
+h-[4px] w-full bg-bg-primary
+`;
 
 export default My;

--- a/src/utils/getImgSrc.ts
+++ b/src/utils/getImgSrc.ts
@@ -1,0 +1,25 @@
+export const getSelectedImg = (name: string) => {
+  const src = name.includes('인생네컷')
+    ? '/svg/marker_select_pink.svg'
+    : name.includes('하루필름')
+    ? '/svg/marker_select_blue.svg'
+    : name.includes('포토이즘')
+    ? '/svg/marker_select_black.svg'
+    : name.includes('포토그레이')
+    ? '/svg/marker_select_gray.svg'
+    : '/svg/marker_select_white.svg';
+  return src;
+};
+
+export const getDefaultImg = (name: string) => {
+  const src = name.includes('인생네컷')
+    ? '/svg/marker_pink.svg'
+    : name.includes('하루필름')
+    ? '/svg/marker_blue.svg'
+    : name.includes('포토이즘')
+    ? '/svg/marker_black.svg'
+    : name.includes('포토그레이')
+    ? '/svg/marker_gray.svg'
+    : '/svg/marker_white.svg';
+  return src;
+};


### PR DESCRIPTION
## 🛠 작업 내용

close #55 

- 로그인이 필요한 페이지를 나누고, 해당 페이지 접근 시 모달을 띄우도록 구현했습니다.
- Map 컴포넌트 내에서 사용하던 이미지 관련 함수를 util 함수로 뺐습니다.
- 해당 pr 머지 후 배포 진행하도록 하겠습니다.

## 📸 스크린샷 or GIF


https://user-images.githubusercontent.com/79186378/232306927-ca8ced11-324e-4f39-a912-6f240dfda387.mov


