### PR TITLE
fix: #71/비로그인 시 상세페이지 접근 불가능한 현상 해결

### DIFF
--- a/src/apis/favorite/favoriteApi.ts
+++ b/src/apis/favorite/favoriteApi.ts
@@ -1,13 +1,9 @@
 import instance from '@apis/instance';
 
 class FavoriteApi {
-  getAllFavorites = async (
-    lng: number,
-    lat: number,
-    sort?: string,
-  ): Promise<Favorite[]> => {
+  getAllFavorites = async (lng: number, lat: number): Promise<Favorite[]> => {
     const { data } = await instance.get(
-      `/favorites?longitude=${lng}&latitude=${lat}&sort=${sort}`,
+      `/favorites?longitude=${lng}&latitude=${lat}`,
     );
     return data;
   };

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -1,11 +1,9 @@
-/* eslint-disable tailwindcss/classnames-order */
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import tw from 'tailwind-styled-components';
 import FavoriteButton from '@components/wish/FavoriteButton';
 import Search from '@components/navbar/Search';
-import { useGetShopDetail } from '@hooks/queries/useGetShop';
 
 type NavBarProps = {
   title?: string;
@@ -14,7 +12,7 @@ type NavBarProps = {
   isRight?: boolean;
   isDetail?: boolean;
   shopId?: number;
-  distance?: string;
+  isFavorite?: boolean;
 };
 
 const NavBar = ({
@@ -24,7 +22,7 @@ const NavBar = ({
   isRight,
   isDetail,
   shopId,
-  distance,
+  isFavorite,
 }: NavBarProps) => {
   const router = useRouter();
   const [isInput, setIsInput] = useState<boolean>(false);
@@ -130,9 +128,9 @@ const NavBar = ({
             />
           )
         ) : null}
-        {isDetail && shopId && distance ? (
-          <FavoriteButton shopId={shopId} distance={distance} />
-        ) : null}
+        {isDetail && shopId && (
+          <FavoriteButton shopId={shopId} isFavorite={isFavorite} />
+        )}
       </NavItems>
     </NavContainer>
   );

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import tw from 'tailwind-styled-components';
 import FavoriteButton from '@components/wish/FavoriteButton';
 import Search from '@components/navbar/Search';
+import { useGetShopDetail } from '@hooks/queries/useGetShop';
 
 type NavBarProps = {
   title?: string;
@@ -13,7 +14,7 @@ type NavBarProps = {
   isRight?: boolean;
   isDetail?: boolean;
   shopId?: number;
-  distance: string;
+  distance?: string;
 };
 
 const NavBar = ({
@@ -55,7 +56,7 @@ const NavBar = ({
             {isMap && (
               <>
                 <div
-                  className="ml-1 flex flex-col items-center"
+                  className="flex flex-col items-center ml-1"
                   onClick={() => {
                     setIsMap(false);
                     setIsList(true);
@@ -75,7 +76,7 @@ const NavBar = ({
             {isList && (
               <>
                 <div
-                  className="ml-1 flex flex-col items-center"
+                  className="flex flex-col items-center ml-1"
                   onClick={() => {
                     setIsList(false);
                     setIsMap(true);
@@ -129,7 +130,7 @@ const NavBar = ({
             />
           )
         ) : null}
-        {isRight && isDetail && shopId ? (
+        {isDetail && shopId && distance ? (
           <FavoriteButton shopId={shopId} distance={distance} />
         ) : null}
       </NavItems>

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -13,6 +13,7 @@ type NavBarProps = {
   isRight?: boolean;
   isDetail?: boolean;
   shopId?: number;
+  distance: string;
 };
 
 const NavBar = ({
@@ -22,6 +23,7 @@ const NavBar = ({
   isRight,
   isDetail,
   shopId,
+  distance,
 }: NavBarProps) => {
   const router = useRouter();
   const [isInput, setIsInput] = useState<boolean>(false);
@@ -53,7 +55,7 @@ const NavBar = ({
             {isMap && (
               <>
                 <div
-                  className="flex flex-col items-center ml-1"
+                  className="ml-1 flex flex-col items-center"
                   onClick={() => {
                     setIsMap(false);
                     setIsList(true);
@@ -73,7 +75,7 @@ const NavBar = ({
             {isList && (
               <>
                 <div
-                  className="flex flex-col items-center ml-1"
+                  className="ml-1 flex flex-col items-center"
                   onClick={() => {
                     setIsList(false);
                     setIsMap(true);
@@ -128,7 +130,7 @@ const NavBar = ({
           )
         ) : null}
         {isRight && isDetail && shopId ? (
-          <FavoriteButton shopId={shopId} />
+          <FavoriteButton shopId={shopId} distance={distance} />
         ) : null}
       </NavItems>
     </NavContainer>

--- a/src/components/common/ToastMessage.tsx
+++ b/src/components/common/ToastMessage.tsx
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
 type ToastProps = {
   text: string;
-  setToast?: Dispatch<SetStateAction<boolean>>;
+  setToast: Dispatch<SetStateAction<boolean>>;
 };
 
 const ToastMessage = ({ text, setToast }: ToastProps) => {
@@ -10,7 +10,7 @@ const ToastMessage = ({ text, setToast }: ToastProps) => {
   useEffect(() => {
     const timer = setTimeout(() => {
       setOpacity(0);
-      // setToast(false);
+      setToast(false);
     }, 1000);
     return () => {
       clearTimeout(timer);
@@ -24,7 +24,7 @@ const ToastMessage = ({ text, setToast }: ToastProps) => {
           className={`mx-12 flex items-center justify-center rounded bg-black px-4 py-3`}
           style={{ opacity: opacity, transition: 'opacity 0.5s ease' }}
         >
-          <span className="text-label2 text-white">{text}</span>
+          <span className="text-white text-label2">{text}</span>
         </div>
       }
     </>

--- a/src/components/home/ShopModal.tsx
+++ b/src/components/home/ShopModal.tsx
@@ -1,8 +1,9 @@
 import BrandTag from '@components/common/BrandTag';
 import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
-import { usePostFavorites } from '@hooks/mutations/usePostFavorite';
+import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 
 type ShopModalProps = {
   id: number;
@@ -24,28 +25,33 @@ const ShopModal = ({
   favorite_cnt,
 }: ShopModalProps) => {
   const router = useRouter();
-  const { mutate: add } = usePostFavorites();
+  const [isFavorite, setIsFavorite] = useState<boolean>(favorite);
+  const { mutate: add } = usePostFavorite();
   const { mutate: del } = useDeleteFavorite();
 
   const handleAddFavorite = (id: number) => {
     add(id);
+    setIsFavorite(true);
   };
   const handleDeleteFavorite = (id: number) => {
     del(id);
+    setIsFavorite(false);
   };
 
   return (
-    <div
-      onClick={() =>
-        router.push(`/shopDetail?shopId=${id}&distance=${distance}`)
-      }
-      className="mx-6 h-[98px] cursor-pointer rounded-[8px] bg-bg-secondary shadow-shopModal"
-    >
+    <div className="mx-6 h-[98px] cursor-pointer rounded-[8px] bg-bg-secondary shadow-shopModal">
       <div className="p-4">
         <BrandTag name={place_name} />
         <div className="flex justify-between pt-1 pb-2">
-          <span className="text-label1">{place_name}</span>
-          {!favorite ? (
+          <span
+            className="text-label1"
+            onClick={() =>
+              router.push(`/shopDetail?shopId=${id}&distance=${distance}`)
+            }
+          >
+            {place_name}
+          </span>
+          {isFavorite ? (
             <Image
               src="/svg/wish/filled-bookmark.svg"
               width={24}
@@ -70,9 +76,9 @@ const ShopModal = ({
               <Image src="/svg/star.svg" width={16} height={16} alt="star" />
               {star_rating_avg}({review_cnt})
             </span>
-            <div className="border-l pl-2">
+            <div className="pl-2 border-l">
               <span className="pr-1">찜</span>
-              <span className="font-semibold">{review_cnt}</span>
+              <span className="font-semibold">{favorite_cnt}</span>
             </div>
           </div>
           <span>{distance}</span>

--- a/src/components/navbar/SearchList.tsx
+++ b/src/components/navbar/SearchList.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import tw from 'tailwind-styled-components';
 
 type SearchListProps = Shop & {
@@ -13,11 +14,18 @@ const SearchList = ({
   place_name,
   distance,
   isList,
+  id,
 }: SearchListProps) => {
+  const router = useRouter();
   return isList ? (
     <>
       <DivisionBar />
-      <li className="cursor-pointer bg-white px-3 py-2">
+      <li
+        className="px-3 py-2 bg-white cursor-pointer"
+        onClick={() =>
+          router.push(`/shopDetail/?shopId=${id}&distance=${distance}`)
+        }
+      >
         <span className="text-label1">{place_name}</span>
         <div className="flex gap-x-1">
           <Image
@@ -38,7 +46,7 @@ const SearchList = ({
             </span>
           </span>
         </div>
-        <div className="mt-2 flex items-center gap-x-1">
+        <div className="flex items-center mt-2 gap-x-1">
           <span className="text-caption2">{distance}</span>
           <span className="text-caption1 text-text-alternative">
             | {road_address_name}

--- a/src/components/navbar/SearchResult.tsx
+++ b/src/components/navbar/SearchResult.tsx
@@ -12,7 +12,6 @@ const SearchResult = ({
   place_name,
   distance,
   road_address_name,
-  id,
 }: SearchProps) => {
   const parts = place_name.split(value);
   return isTyping ? (

--- a/src/components/navbar/SearchResult.tsx
+++ b/src/components/navbar/SearchResult.tsx
@@ -31,29 +31,29 @@ const SearchResult = ({
           </div>
           <div className="ml-4 flex flex-col">
             <div className="flex">
-              {parts.map((part, index) => {
-                if (index === 0) {
-                  return (
-                    <span key={index} className="text-label1 text-status-error">
+              {parts.length > 1 ? (
+                parts[0] !== parts[0]?.trim() ? (
+                  <>
+                    <span className="text-label1 text-black">{parts[0]}</span>
+                    <span className="text-label1 text-status-error">
+                      &nbsp;{value}
+                    </span>
+                    <span className="text-label1 text-black">{parts[1]}</span>
+                  </>
+                ) : (
+                  <>
+                    <span className="text-label1 text-black">{parts[0]}</span>
+                    <span className="text-label1 text-status-error">
                       {value}
                     </span>
-                  );
-                } else if (value === place_name.split(' ')[0]) {
-                  return (
-                    <span key={index} className="text-label1 text-black">
-                      <span className="tracking-[-0.3rem]">&nbsp;</span>
-                      {part}
-                    </span>
-                  );
-                }
-                return (
-                  <span key={index} className="text-label1 text-black">
-                    {part}
-                  </span>
-                );
-              })}
+                    <span className="text-label1 text-black">{parts[1]}</span>
+                  </>
+                )
+              ) : (
+                place_name
+              )}
             </div>
-            <span className=" text-caption1 text-text-alternative">
+            <span className="text-caption1 text-text-alternative">
               {road_address_name}
             </span>
           </div>

--- a/src/components/wish/FavoriteButton.tsx
+++ b/src/components/wish/FavoriteButton.tsx
@@ -74,26 +74,6 @@ const FavoriteButton = ({ shopId, isWish, distance }: FavortieButtonProps) => {
       {!isWish &&
         isFetched &&
         (shopInfo?.favorite ? (
-          !getToken().accessToken ? (
-            <Image
-              src="/svg/wish/lined-bookmark.svg"
-              width={24}
-              height={24}
-              alt="bookmark"
-              className="z-[900] cursor-pointer"
-              onClick={() => setIsLogin(true)}
-            />
-          ) : (
-            <Image
-              src="/svg/wish/lined-bookmark.svg"
-              width={24}
-              height={24}
-              alt="bookmark"
-              className="z-[900] cursor-pointer"
-              onClick={() => handleAddFavorite(shopId)}
-            />
-          )
-        ) : (
           <Image
             src="/svg/wish/filled-bookmark.svg"
             width={24}
@@ -104,6 +84,24 @@ const FavoriteButton = ({ shopId, isWish, distance }: FavortieButtonProps) => {
               handleDeleteFavorite(shopId);
               handleToast();
             }}
+          />
+        ) : !getToken().accessToken ? (
+          <Image
+            src="/svg/wish/lined-bookmark.svg"
+            width={24}
+            height={24}
+            alt="bookmark"
+            className="z-[900] cursor-pointer"
+            onClick={() => setIsLogin(true)}
+          />
+        ) : (
+          <Image
+            src="/svg/wish/lined-bookmark.svg"
+            width={24}
+            height={24}
+            alt="bookmark"
+            className="z-[900] cursor-pointer"
+            onClick={() => handleAddFavorite(shopId)}
           />
         ))}
 

--- a/src/components/wish/FavoriteButton.tsx
+++ b/src/components/wish/FavoriteButton.tsx
@@ -1,27 +1,20 @@
 import Image from 'next/image';
 import { useState } from 'react';
-import { queryClient } from 'pages/_app';
 import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
-import { usePostFavorites } from '@hooks/mutations/usePostFavorite';
 import Modal from '@components/common/Modal';
 import ToastMessage from '@components/common/ToastMessage';
 import tw from 'tailwind-styled-components';
-import { useGetShopDetail } from '@hooks/queries/useGetShop';
 import { getToken } from '@utils/token';
+import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
 
 type FavortieButtonProps = {
   shopId: number;
-  isWish?: boolean;
-  distance: string;
+  isFavorite?: boolean;
 };
 
-const FavoriteButton = ({ shopId, isWish, distance }: FavortieButtonProps) => {
-  const { data: shopInfo, isFetched } = useGetShopDetail(shopId, distance);
+const FavoriteButton = ({ shopId, isFavorite }: FavortieButtonProps) => {
   const { mutate: del, isSuccess, isError } = useDeleteFavorite();
-  const { mutate: add } = usePostFavorites();
-  const favoritesCache = queryClient.getQueryData<Favorite[]>([
-    'useGetFavorites',
-  ]);
+  const { mutate: add } = usePostFavorite();
 
   const [isModal, setIsModal] = useState<boolean>(false);
   const [isLogin, setIsLogin] = useState<boolean>(false);
@@ -40,67 +33,39 @@ const FavoriteButton = ({ shopId, isWish, distance }: FavortieButtonProps) => {
     setToast(true);
   };
 
-  const favCacheArray = favoritesCache?.map((fav) => fav.shop.id);
-
   return (
     <>
-      {isWish &&
-        (favCacheArray?.includes(shopId) ? (
-          <Image
-            src="/svg/wish/filled-bookmark.svg"
-            width={24}
-            height={24}
-            alt="bookmark"
-            className="cursor-pointer"
-            onClick={() => {
-              setIsModal(true);
-              setToast(true);
-            }}
-          />
-        ) : (
-          <Image
-            src="/svg/wish/lined-bookmark.svg"
-            width={24}
-            height={24}
-            alt="bookmark"
-            className="cursor-pointer"
-            onClick={() => handleAddFavorite(shopId)}
-          />
-        ))}
-
-      {!isWish &&
-        isFetched &&
-        (shopInfo?.favorite ? (
-          <Image
-            src="/svg/wish/filled-bookmark.svg"
-            width={24}
-            height={24}
-            alt="bookmark"
-            className="z-[900] cursor-pointer"
-            onClick={() => {
-              handleDeleteFavorite(shopId);
-              handleToast();
-            }}
-          />
-        ) : !getToken().accessToken ? (
-          <Image
-            src="/svg/wish/lined-bookmark.svg"
-            width={24}
-            height={24}
-            alt="bookmark"
-            className="z-[900] cursor-pointer"
-            onClick={() => setIsLogin(true)}
-          />
-        ) : (
-          <Image
-            src="/svg/wish/lined-bookmark.svg"
-            width={24}
-            height={24}
-            alt="bookmark"
-            className="z-[900] cursor-pointer"
-            onClick={() => handleAddFavorite(shopId)}
-          />
-        ))}
+      {isFavorite ? (
+        <Image
+          src="/svg/wish/filled-bookmark.svg"
+          width={24}
+          height={24}
+          alt="bookmark"
+          className="z-[900] cursor-pointer"
+          onClick={() => {
+            handleDeleteFavorite(shopId);
+            handleToast();
+          }}
+        />
+      ) : !getToken().accessToken ? (
+        <Image
+          src="/svg/wish/lined-bookmark.svg"
+          width={24}
+          height={24}
+          alt="bookmark"
+          className="z-[900] cursor-pointer"
+          onClick={() => setIsLogin(true)}
+        />
+      ) : (
+        <Image
+          src="/svg/wish/lined-bookmark.svg"
+          width={24}
+          height={24}
+          alt="bookmark"
+          className="z-[900] cursor-pointer"
+          onClick={() => handleAddFavorite(shopId)}
+        />
+      )}
 
       {isModal && (
         <ModalLayout>

--- a/src/components/wish/FavoriteButton.tsx
+++ b/src/components/wish/FavoriteButton.tsx
@@ -6,7 +6,6 @@ import { usePostFavorites } from '@hooks/mutations/usePostFavorite';
 import Modal from '@components/common/Modal';
 import ToastMessage from '@components/common/ToastMessage';
 import tw from 'tailwind-styled-components';
-import { getLocalStorage } from '@utils/localStorage';
 import { useGetShopDetail } from '@hooks/queries/useGetShop';
 import { getToken } from '@utils/token';
 
@@ -23,8 +22,6 @@ const FavoriteButton = ({ shopId, isWish, distance }: FavortieButtonProps) => {
   const favoritesCache = queryClient.getQueryData<Favorite[]>([
     'useGetFavorites',
   ]);
-
-  console.log(!getToken().accessToken);
 
   const [isModal, setIsModal] = useState<boolean>(false);
   const [isLogin, setIsLogin] = useState<boolean>(false);

--- a/src/components/wish/FavoriteButton.tsx
+++ b/src/components/wish/FavoriteButton.tsx
@@ -8,6 +8,7 @@ import ToastMessage from '@components/common/ToastMessage';
 import tw from 'tailwind-styled-components';
 import { getLocalStorage } from '@utils/localStorage';
 import { useGetShopDetail } from '@hooks/queries/useGetShop';
+import { getToken } from '@utils/token';
 
 type FavortieButtonProps = {
   shopId: number;
@@ -22,6 +23,8 @@ const FavoriteButton = ({ shopId, isWish, distance }: FavortieButtonProps) => {
   const favoritesCache = queryClient.getQueryData<Favorite[]>([
     'useGetFavorites',
   ]);
+
+  console.log(!getToken().accessToken);
 
   const [isModal, setIsModal] = useState<boolean>(false);
   const [isLogin, setIsLogin] = useState<boolean>(false);
@@ -71,7 +74,7 @@ const FavoriteButton = ({ shopId, isWish, distance }: FavortieButtonProps) => {
       {!isWish &&
         isFetched &&
         (shopInfo?.favorite ? (
-          !getLocalStorage('@token') ? (
+          !getToken().accessToken ? (
             <Image
               src="/svg/wish/lined-bookmark.svg"
               width={24}

--- a/src/components/wish/FavoriteButton.tsx
+++ b/src/components/wish/FavoriteButton.tsx
@@ -1,11 +1,13 @@
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { queryClient } from 'pages/_app';
 import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
 import { usePostFavorites } from '@hooks/mutations/usePostFavorite';
 import { useGetFavorite } from '@hooks/queries/useGetFavorite';
 import Modal from '@components/common/Modal';
 import ToastMessage from '@components/common/ToastMessage';
+import tw from 'tailwind-styled-components';
+import { getLocalStorage } from '@utils/localStorage';
 
 type FavortieButtonProps = {
   shopId: number;
@@ -21,6 +23,7 @@ const FavoriteButton = ({ shopId, isWish }: FavortieButtonProps) => {
   ]);
 
   const [isModal, setIsModal] = useState<boolean>(false);
+  const [isLogin, setIsLogin] = useState<boolean>(false);
   const [toast, setToast] = useState<boolean>(false);
 
   const handleAddFavorite = (shopId: number) => {
@@ -77,6 +80,15 @@ const FavoriteButton = ({ shopId, isWish }: FavortieButtonProps) => {
               handleToast();
             }}
           />
+        ) : !getLocalStorage('@token') ? (
+          <Image
+            src="/svg/wish/lined-bookmark.svg"
+            width={24}
+            height={24}
+            alt="bookmark"
+            className="z-[900] cursor-pointer"
+            onClick={() => setIsLogin(true)}
+          />
         ) : (
           <Image
             src="/svg/wish/lined-bookmark.svg"
@@ -89,7 +101,7 @@ const FavoriteButton = ({ shopId, isWish }: FavortieButtonProps) => {
         ))}
 
       {isModal && (
-        <div className="absolute top-0 left-0 h-full w-full">
+        <ModalLayout>
           <Modal
             isModal={isModal}
             isKakao={false}
@@ -105,7 +117,19 @@ const FavoriteButton = ({ shopId, isWish }: FavortieButtonProps) => {
               setIsModal(false);
             }}
           />
-        </div>
+        </ModalLayout>
+      )}
+      {isLogin && (
+        <ModalLayout>
+          <Modal
+            isModal={true}
+            isKakao={true}
+            title="로그인 상태가 아니에요!"
+            message="해당 기능은 카카오톡 로그인을 하셔야 이용가능한 기능이에요. 로그인 하시겠어요?"
+            left="아니요"
+            leftEvent={() => setIsLogin(false)}
+          />
+        </ModalLayout>
       )}
 
       {toast && isSuccess && (
@@ -128,5 +152,9 @@ const FavoriteButton = ({ shopId, isWish }: FavortieButtonProps) => {
     </>
   );
 };
+
+const ModalLayout = tw.div`
+absolute top-0 left-0 w-full h-full
+`;
 
 export default FavoriteButton;

--- a/src/components/wish/FavoriteButton.tsx
+++ b/src/components/wish/FavoriteButton.tsx
@@ -1,21 +1,22 @@
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { queryClient } from 'pages/_app';
 import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
 import { usePostFavorites } from '@hooks/mutations/usePostFavorite';
-import { useGetFavorite } from '@hooks/queries/useGetFavorite';
 import Modal from '@components/common/Modal';
 import ToastMessage from '@components/common/ToastMessage';
 import tw from 'tailwind-styled-components';
 import { getLocalStorage } from '@utils/localStorage';
+import { useGetShopDetail } from '@hooks/queries/useGetShop';
 
 type FavortieButtonProps = {
   shopId: number;
   isWish?: boolean;
+  distance: string;
 };
 
-const FavoriteButton = ({ shopId, isWish }: FavortieButtonProps) => {
-  const { data: favorites } = useGetFavorite(127.052068, 37.545704, 'created');
+const FavoriteButton = ({ shopId, isWish, distance }: FavortieButtonProps) => {
+  const { data: shopInfo, isFetched } = useGetShopDetail(shopId, distance);
   const { mutate: del, isSuccess, isError } = useDeleteFavorite();
   const { mutate: add } = usePostFavorites();
   const favoritesCache = queryClient.getQueryData<Favorite[]>([
@@ -40,7 +41,6 @@ const FavoriteButton = ({ shopId, isWish }: FavortieButtonProps) => {
   };
 
   const favCacheArray = favoritesCache?.map((fav) => fav.shop.id);
-  const favArray = favorites?.map((fav) => fav.shop.id);
 
   return (
     <>
@@ -67,8 +67,30 @@ const FavoriteButton = ({ shopId, isWish }: FavortieButtonProps) => {
             onClick={() => handleAddFavorite(shopId)}
           />
         ))}
+
       {!isWish &&
-        (favArray?.includes(shopId) ? (
+        isFetched &&
+        (shopInfo?.favorite ? (
+          !getLocalStorage('@token') ? (
+            <Image
+              src="/svg/wish/lined-bookmark.svg"
+              width={24}
+              height={24}
+              alt="bookmark"
+              className="z-[900] cursor-pointer"
+              onClick={() => setIsLogin(true)}
+            />
+          ) : (
+            <Image
+              src="/svg/wish/lined-bookmark.svg"
+              width={24}
+              height={24}
+              alt="bookmark"
+              className="z-[900] cursor-pointer"
+              onClick={() => handleAddFavorite(shopId)}
+            />
+          )
+        ) : (
           <Image
             src="/svg/wish/filled-bookmark.svg"
             width={24}
@@ -79,24 +101,6 @@ const FavoriteButton = ({ shopId, isWish }: FavortieButtonProps) => {
               handleDeleteFavorite(shopId);
               handleToast();
             }}
-          />
-        ) : !getLocalStorage('@token') ? (
-          <Image
-            src="/svg/wish/lined-bookmark.svg"
-            width={24}
-            height={24}
-            alt="bookmark"
-            className="z-[900] cursor-pointer"
-            onClick={() => setIsLogin(true)}
-          />
-        ) : (
-          <Image
-            src="/svg/wish/lined-bookmark.svg"
-            width={24}
-            height={24}
-            alt="bookmark"
-            className="z-[900] cursor-pointer"
-            onClick={() => handleAddFavorite(shopId)}
           />
         ))}
 

--- a/src/components/wish/WishItem.tsx
+++ b/src/components/wish/WishItem.tsx
@@ -19,7 +19,11 @@ const WishItem = ({ shop }: Favorite) => {
         >
           {shop.place_name}
         </span>
-        <FavoriteButton shopId={shop.id} isWish={true} />
+        <FavoriteButton
+          shopId={shop.id}
+          isWish={true}
+          distance={shop.distance}
+        />
       </div>
       <div className="flex justify-between">
         <div className="flex items-center gap-1">

--- a/src/components/wish/WishItem.tsx
+++ b/src/components/wish/WishItem.tsx
@@ -1,44 +1,133 @@
 import BrandTag from '@components/common/BrandTag';
-import FavoriteButton from '@components/wish/FavoriteButton';
+import Modal from '@components/common/Modal';
+import ToastMessage from '@components/common/ToastMessage';
+import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
+import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
+import tw from 'tailwind-styled-components';
 
 const WishItem = ({ shop }: Favorite) => {
   const router = useRouter();
+  const [isModal, setIsModal] = useState<boolean>(false);
+  const [isLogin, setIsLogin] = useState<boolean>(false);
+  const [toast, setToast] = useState<boolean>(false);
+  const { mutate: del, isSuccess, isError } = useDeleteFavorite();
+  const { mutate: add } = usePostFavorite();
+
+  const handleAddFavorite = (shopId: number) => {
+    add(shopId);
+  };
+
+  const handleDeleteFavorite = (shopId: number) => {
+    del(shopId);
+  };
+
   return (
-    <li className="w-full bg-white px-6 py-5">
-      <BrandTag name={shop.place_name} />
-      <div className="flex justify-between pt-1 pb-2">
-        <span
-          className="cursor-pointer text-body1"
-          onClick={() =>
-            router.push(
-              `/shopDetail/?shopId=${shop.id}&distance=${shop.distance}`,
-            )
-          }
-        >
-          {shop.place_name}
-        </span>
-        <FavoriteButton
-          shopId={shop.id}
-          isWish={true}
-          distance={shop.distance}
-        />
-      </div>
-      <div className="flex justify-between">
-        <div className="flex items-center gap-1">
-          <Image src="/svg/star.svg" width={14} height={14} alt="star" />
-          <span className="text-caption1">
-            {shop.star_rating_avg.toFixed(1)} ({shop.review_cnt}) | 찜{' '}
+    <>
+      <li className="w-full bg-white px-6 py-5">
+        <BrandTag name={shop.place_name} />
+        <div className="flex justify-between pt-1 pb-2">
+          <span
+            className="cursor-pointer text-body1"
+            onClick={() =>
+              router.push(
+                `/shopDetail/?shopId=${shop.id}&distance=${shop.distance}`,
+              )
+            }
+          >
+            {shop.place_name}
           </span>
-          <span className="text-caption1 font-semibold">
-            {shop.favorite_cnt}
-          </span>
+          {shop.id ? (
+            <Image
+              src="/svg/wish/filled-bookmark.svg"
+              width={24}
+              height={24}
+              alt="bookmark"
+              className="z-[900] cursor-pointer"
+              onClick={() => {
+                setIsModal(true);
+                setToast(true);
+              }}
+            />
+          ) : (
+            <Image
+              src="/svg/wish/lined-bookmark.svg"
+              width={24}
+              height={24}
+              alt="bookmark"
+              className="z-[900] cursor-pointer"
+              onClick={() => handleAddFavorite(shop.id)}
+            />
+          )}
         </div>
-        <span className="text-caption1">{shop.distance}</span>
-      </div>
-    </li>
+        <div className="flex justify-between">
+          <div className="flex items-center gap-1">
+            <Image src="/svg/star.svg" width={14} height={14} alt="star" />
+            <span className="text-caption1">
+              {shop.star_rating_avg.toFixed(1)} ({shop.review_cnt}) | 찜{' '}
+            </span>
+            <span className="text-caption1 font-semibold">
+              {shop.favorite_cnt}
+            </span>
+          </div>
+          <span className="text-caption1">{shop.distance}</span>
+        </div>
+      </li>
+      {isModal && (
+        <ModalLayout>
+          <Modal
+            isModal={isModal}
+            isKakao={false}
+            title="저장 취소"
+            message="해당 지점이 삭제돼요. 저장 페이지에서 삭제 진행하시겠어요?"
+            left="저장 유지"
+            right="저장 취소"
+            leftEvent={() => {
+              setIsModal(false);
+            }}
+            rightEvent={() => {
+              handleDeleteFavorite(shop.id);
+              setIsModal(false);
+            }}
+          />
+        </ModalLayout>
+      )}
+      {isLogin && (
+        <ModalLayout>
+          <Modal
+            isModal={true}
+            isKakao={true}
+            title="로그인 상태가 아니에요!"
+            message="해당 기능은 카카오톡 로그인을 하셔야 이용가능한 기능이에요. 로그인 하시겠어요?"
+            left="아니요"
+            leftEvent={() => setIsLogin(false)}
+          />
+        </ModalLayout>
+      )}
+      {toast && isSuccess && (
+        <div className="fixed bottom-0 z-[900] pb-[71px]">
+          <ToastMessage
+            text="저장페이지에서 지점이 삭제되었습니다."
+            setToast={setToast}
+          />
+        </div>
+      )}
+      {toast && isError && (
+        <div className="fixed bottom-0 z-[900] w-full max-w-[375px] pb-[71px]">
+          <ToastMessage
+            text="오류가 발생했습니다. 다시 시도해주세요."
+            setToast={setToast}
+          />
+        </div>
+      )}
+    </>
   );
 };
+
+const ModalLayout = tw.div`
+absolute top-0 left-0 w-full h-full
+`;
 
 export default WishItem;

--- a/src/hooks/mutations/useDeleteFavorite.ts
+++ b/src/hooks/mutations/useDeleteFavorite.ts
@@ -11,6 +11,9 @@ export const useDeleteFavorite = () => {
           queryClient.invalidateQueries({
             queryKey: ['useGetFavorites'],
           });
+          queryClient.invalidateQueries({
+            queryKey: ['useGetShopDetail'],
+          });
         }, 1000);
       },
     },

--- a/src/hooks/mutations/usePostFavorite.ts
+++ b/src/hooks/mutations/usePostFavorite.ts
@@ -10,6 +10,9 @@ export const usePostFavorites = () => {
         queryClient.invalidateQueries({
           queryKey: ['useGetFavorites'],
         });
+        queryClient.invalidateQueries({
+          queryKey: ['useGetShopDetail'],
+        });
       },
     },
   );

--- a/src/hooks/mutations/usePostFavorite.ts
+++ b/src/hooks/mutations/usePostFavorite.ts
@@ -1,8 +1,8 @@
 import favoriteApi from '@apis/favorite/favoriteApi';
 import { queryClient } from 'pages/_app';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation } from 'react-query';
 
-export const usePostFavorites = () => {
+export const usePostFavorite = () => {
   return useMutation<void, void, number, unknown>(
     (shopId: number) => favoriteApi.postFavorites(shopId),
     {

--- a/src/hooks/queries/useGetFavorite.ts
+++ b/src/hooks/queries/useGetFavorite.ts
@@ -1,4 +1,5 @@
 import favoriteApi from '@apis/favorite/favoriteApi';
+import { getLocalStorage } from '@utils/localStorage';
 import { useQuery } from 'react-query';
 
 export const useGetFavorite = (lng: number, lat: number, sort: string) => {
@@ -6,6 +7,7 @@ export const useGetFavorite = (lng: number, lat: number, sort: string) => {
     ['useGetFavorites'],
     () => favoriteApi.getAllFavorites(lng, lat, sort),
     {
+      enabled: !!getLocalStorage('@token'),
       retry: false,
       refetchOnWindowFocus: false,
     },

--- a/src/hooks/queries/useGetFavorite.ts
+++ b/src/hooks/queries/useGetFavorite.ts
@@ -1,10 +1,10 @@
 import favoriteApi from '@apis/favorite/favoriteApi';
 import { useQuery } from 'react-query';
 
-export const useGetFavorite = (lng: number, lat: number, sort: string) => {
+export const useGetFavorite = (lng: number, lat: number) => {
   return useQuery<Favorite[], Error>(
     ['useGetFavorites'],
-    () => favoriteApi.getAllFavorites(lng, lat, sort),
+    () => favoriteApi.getAllFavorites(lng, lat),
     {
       retry: false,
       refetchOnWindowFocus: false,

--- a/src/hooks/queries/useGetFavorite.ts
+++ b/src/hooks/queries/useGetFavorite.ts
@@ -1,5 +1,6 @@
 import favoriteApi from '@apis/favorite/favoriteApi';
 import { getLocalStorage } from '@utils/localStorage';
+import { getToken } from '@utils/token';
 import { useQuery } from 'react-query';
 
 export const useGetFavorite = (lng: number, lat: number, sort: string) => {
@@ -7,7 +8,7 @@ export const useGetFavorite = (lng: number, lat: number, sort: string) => {
     ['useGetFavorites'],
     () => favoriteApi.getAllFavorites(lng, lat, sort),
     {
-      enabled: !!getLocalStorage('@token'),
+      enabled: !!getToken().accessToken,
       retry: false,
       refetchOnWindowFocus: false,
     },

--- a/src/hooks/queries/useGetFavorite.ts
+++ b/src/hooks/queries/useGetFavorite.ts
@@ -1,5 +1,4 @@
 import favoriteApi from '@apis/favorite/favoriteApi';
-import { getToken } from '@utils/token';
 import { useQuery } from 'react-query';
 
 export const useGetFavorite = (lng: number, lat: number, sort: string) => {

--- a/src/hooks/queries/useGetFavorite.ts
+++ b/src/hooks/queries/useGetFavorite.ts
@@ -1,5 +1,4 @@
 import favoriteApi from '@apis/favorite/favoriteApi';
-import { getLocalStorage } from '@utils/localStorage';
 import { getToken } from '@utils/token';
 import { useQuery } from 'react-query';
 
@@ -8,7 +7,6 @@ export const useGetFavorite = (lng: number, lat: number, sort: string) => {
     ['useGetFavorites'],
     () => favoriteApi.getAllFavorites(lng, lat, sort),
     {
-      enabled: !!getToken().accessToken,
       retry: false,
       refetchOnWindowFocus: false,
     },

--- a/src/hooks/queries/useGetReview.ts
+++ b/src/hooks/queries/useGetReview.ts
@@ -32,7 +32,7 @@ export const useGetAllShopReviews = (shopId: number) => {
     {
       retry: false,
       refetchOnWindowFocus: false,
-      enabled: !!shopId && !!getLocalStorage('@token'), // shopId가 true면 뒤에 판단
+      enabled: !!shopId && !!getLocalStorage('@token'),
     },
   );
 };

--- a/src/hooks/queries/useGetReview.ts
+++ b/src/hooks/queries/useGetReview.ts
@@ -1,5 +1,4 @@
 import reviewApi from '@apis/review/reviewApi';
-import { getLocalStorage } from '@utils/localStorage';
 import { useQuery } from 'react-query';
 
 export const useGetAllUserReviews = () => {

--- a/src/hooks/queries/useGetReview.ts
+++ b/src/hooks/queries/useGetReview.ts
@@ -32,7 +32,7 @@ export const useGetAllShopReviews = (shopId: number) => {
     {
       retry: false,
       refetchOnWindowFocus: false,
-      enabled: !!shopId && !!getLocalStorage('@token'),
+      enabled: !!shopId,
     },
   );
 };

--- a/src/hooks/queries/useGetReview.ts
+++ b/src/hooks/queries/useGetReview.ts
@@ -1,4 +1,5 @@
 import reviewApi from '@apis/review/reviewApi';
+import { getLocalStorage } from '@utils/localStorage';
 import { useQuery } from 'react-query';
 
 export const useGetAllUserReviews = () => {
@@ -31,7 +32,7 @@ export const useGetAllShopReviews = (shopId: number) => {
     {
       retry: false,
       refetchOnWindowFocus: false,
-      enabled: !!shopId,
+      enabled: !!shopId && !!getLocalStorage('@token'), // shopId가 true면 뒤에 판단
     },
   );
 };

--- a/src/hooks/queries/useGetShop.ts
+++ b/src/hooks/queries/useGetShop.ts
@@ -57,15 +57,6 @@ export const useGetShopsByKeyword = (
     {
       enabled: !!keyword,
       refetchOnWindowFocus: false,
-      select: (data) =>
-        data?.filter(
-          (shop) =>
-            shop.place_name.includes('인생네컷') ||
-            shop.place_name.includes('하루필름') ||
-            shop.place_name.includes('포토시그니처') ||
-            shop.place_name.includes('포토그레이') ||
-            shop.place_name.includes('포토이즘'),
-        ),
     },
   );
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -27,22 +27,24 @@ const queryClient = new QueryClient();
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
   const router = useRouter();
   const loginRequiredPages = ['/my', '/wish'];
-  if (
-    loginRequiredPages.includes(router.pathname) &&
-    !getLocalStorage('@token')
-  ) {
-    return (
-      <Layout>
-        <Modal
-          isModal={true}
-          isKakao={true}
-          title="로그인 상태가 아니에요!"
-          message="해당 페이지는 카카오톡 로그인을 하셔야 이용가능한 페이지에요. 로그인 하시겠어요?"
-          left="아니요"
-          leftEvent={() => router.back()}
-        />
-      </Layout>
-    );
+  if (typeof window !== 'undefined') {
+    if (
+      loginRequiredPages.includes(router.pathname) &&
+      !getLocalStorage('@token')
+    ) {
+      return (
+        <Layout>
+          <Modal
+            isModal={true}
+            isKakao={true}
+            title="로그인 상태가 아니에요!"
+            message="해당 페이지는 카카오톡 로그인을 하셔야 이용가능한 페이지에요. 로그인 하시겠어요?"
+            left="아니요"
+            leftEvent={() => router.back()}
+          />
+        </Layout>
+      );
+    }
   }
   const getLayout = Component.getLayout ?? ((page) => <Layout>{page}</Layout>);
   return getLayout(

--- a/src/pages/shopDetail/index.tsx
+++ b/src/pages/shopDetail/index.tsx
@@ -31,7 +31,7 @@ const ShopDetail = ({ shopId, distance }) => {
         isLeft={true}
         isDetail={true}
         shopId={shopInfo?.id}
-        distance={distance}
+        isFavorite={shopInfo?.favorite}
       />
       <div className="h-[270px] w-full pt-[62px]" ref={mapContainer}></div>
       <ShopInfoBox>

--- a/src/pages/shopDetail/index.tsx
+++ b/src/pages/shopDetail/index.tsx
@@ -29,7 +29,6 @@ const ShopDetail = ({ shopId, distance }) => {
       <Scripts shopInfo={shopInfo as ShopDetail} mapContainer={mapContainer} />
       <NavBar
         isLeft={true}
-        isRight={true}
         isDetail={true}
         shopId={shopInfo?.id}
         distance={distance}
@@ -46,7 +45,7 @@ const ShopDetail = ({ shopId, distance }) => {
             <div className="pl-1 pr-2">
               {shopInfo?.star_rating_avg} ({shopInfo?.review_cnt})
             </div>
-            <div className="border-l border-text-alternative px-2">
+            <div className="px-2 border-l border-text-alternative">
               <span>찜</span>
               <span className="pl-1 font-semibold">
                 {shopInfo?.favorite_cnt}

--- a/src/pages/shopDetail/index.tsx
+++ b/src/pages/shopDetail/index.tsx
@@ -32,6 +32,7 @@ const ShopDetail = ({ shopId, distance }) => {
         isRight={true}
         isDetail={true}
         shopId={shopInfo?.id}
+        distance={distance}
       />
       <div className="h-[270px] w-full pt-[62px]" ref={mapContainer}></div>
       <ShopInfoBox>
@@ -45,7 +46,7 @@ const ShopDetail = ({ shopId, distance }) => {
             <div className="pl-1 pr-2">
               {shopInfo?.star_rating_avg} ({shopInfo?.review_cnt})
             </div>
-            <div className="px-2 border-l border-text-alternative">
+            <div className="border-l border-text-alternative px-2">
               <span>찜</span>
               <span className="pl-1 font-semibold">
                 {shopInfo?.favorite_cnt}

--- a/src/pages/wish/index.tsx
+++ b/src/pages/wish/index.tsx
@@ -5,7 +5,7 @@ import { useGetFavorite } from '@hooks/queries/useGetFavorite';
 import tw from 'tailwind-styled-components';
 
 const Wish = () => {
-  const { data: favorites } = useGetFavorite(127.052068, 37.545704, 'created');
+  const { data: favorites } = useGetFavorite(127.052068, 37.545704);
   return (
     <PageLayout>
       <NavBar title={'저장'} isRight={true} isLeft={true} />


### PR DESCRIPTION
## 🛠 작업 내용

비로그인 시 상세페이지 접근 불가능한 현상 해결
- close #71 

## PR 세부 내용
<!--수정/추가한 작업 내용을 설명해주세요.-->

- 해당 문제는 상세페이지에서 호출하는 `getAllShopReviews`, `getFavorites`가 토큰을 담아 보내야 하는 API라서 발생했습니다.
  - `getAllShopReviews` API는 토큰을 담아 보내지 않아도 되게끔 백엔드에서 수정이 완료되었습니다.
  - `getFavorites` 커스텀 훅에서 `enabled: !!getLocalStorage('@token')`로 설정하였습니다.
- 상세페이지에서도 비로그인 시 찜 버튼을 누른다면 모달이 생기도록 구현하였습니다.
- 검색어 하이라이팅을 처리하는 로직을 수정했습니다.
  - 하지만, 일부 상황에서 띄어쓰기가 처리가 안 되는 버그가 발생합니다. 더 좋은 방법으로 추후에 수정하도록 하겠습니다.
- _app.tsx에서 `if (typeof window !== 'undefined')` 를 추가하였습니다.
  - 찜, 마이페이지에서 새로고침하면 view가 그려지기 전에 pre-rendering 되서 발생하는 에러가 발생했습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
