### PR TITLE
fix: #76/ShopModal 찜 버그 수정

### DIFF
--- a/src/components/home/ShopModal.tsx
+++ b/src/components/home/ShopModal.tsx
@@ -3,7 +3,7 @@ import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
 import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
 type ShopModalProps = {
   id: number;
@@ -13,6 +13,8 @@ type ShopModalProps = {
   review_cnt: number;
   favorite: boolean;
   favorite_cnt: number;
+  isFavorite?: boolean;
+  setIsFavorite: Dispatch<SetStateAction<boolean | undefined>>;
 };
 
 const ShopModal = ({
@@ -23,9 +25,10 @@ const ShopModal = ({
   review_cnt,
   favorite,
   favorite_cnt,
+  isFavorite,
+  setIsFavorite,
 }: ShopModalProps) => {
   const router = useRouter();
-  const [isFavorite, setIsFavorite] = useState<boolean>(favorite);
   const { mutate: add } = usePostFavorite();
   const { mutate: del } = useDeleteFavorite();
 
@@ -57,7 +60,9 @@ const ShopModal = ({
               width={24}
               height={24}
               alt="wish"
-              onClick={() => handleDeleteFavorite(id)}
+              onClick={() => {
+                handleDeleteFavorite(id);
+              }}
             />
           ) : (
             <Image

--- a/src/components/home/ShopModal.tsx
+++ b/src/components/home/ShopModal.tsx
@@ -3,7 +3,7 @@ import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
 import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 
 type ShopModalProps = {
   id: number;

--- a/src/hooks/mutations/useDeleteFavorite.ts
+++ b/src/hooks/mutations/useDeleteFavorite.ts
@@ -14,6 +14,9 @@ export const useDeleteFavorite = () => {
           queryClient.invalidateQueries({
             queryKey: ['useGetShopDetail'],
           });
+          queryClient.invalidateQueries({
+            queryKey: ['useGetShopsInRad'],
+          });
         }, 1000);
       },
     },

--- a/src/hooks/mutations/usePostFavorite.ts
+++ b/src/hooks/mutations/usePostFavorite.ts
@@ -13,6 +13,9 @@ export const usePostFavorite = () => {
         queryClient.invalidateQueries({
           queryKey: ['useGetShopDetail'],
         });
+        queryClient.invalidateQueries({
+          queryKey: ['useGetShopsInRad'],
+        });
       },
     },
   );

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -33,9 +33,17 @@ const Home = () => {
 
   const { data: shopInfo } = useGetShopsInRad(location.lat, location.lng, brd);
 
+  const [isFavorite, setIsFavorite] = useState<boolean | undefined>(
+    modalProps?.favorite,
+  );
+
   useEffect(() => {
     setShopsInfo(shopInfo);
   }, [shopInfo]);
+
+  useEffect(() => {
+    setIsFavorite(modalProps?.favorite);
+  }, [modalProps]);
 
   const handleTracker = () => {
     const { kakao } = window;
@@ -81,6 +89,8 @@ const Home = () => {
             review_cnt={modalProps.review_cnt}
             favorite={modalProps.favorite}
             favorite_cnt={modalProps.favorite_cnt}
+            isFavorite={isFavorite}
+            setIsFavorite={setIsFavorite}
           />
         )}
       </div>


### PR DESCRIPTION
## 🛠 작업 내용

마커 모달 찜 버그 수정
- close #76 

### ⚠️이슈
현재 찜 추가/삭제 시 마커 클릭 상태가 해제되는 현상이 있습니다. 각 마커에 대한 찜 여부를 실시간으로 반영하려면 `shopInfo`가 수정될 수 밖에 없어서 기술적으로 현재 해결 방법을 찾지 못한 상태입니다. 추후에 해결 방안을 고민해보도록 하겠습니다.

<!--수정/추가한 작업 내용을 설명해주세요.-->

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
