### PR TITLE
feat: #84/ 찜 삭제 낙관적 업데이트 구현 & shopModal 찜 버그 수정

### DIFF
--- a/src/components/common/Scripts.tsx
+++ b/src/components/common/Scripts.tsx
@@ -1,6 +1,7 @@
 import Script from 'next/script';
 import { CONFIG } from '@config';
 import { RefObject } from 'react';
+import { getSelectedImg } from '@utils/getImgSrc';
 
 type ScriptsProps = {
   shopInfo: ShopDetail;
@@ -23,7 +24,7 @@ const Scripts = ({ shopInfo, mapContainer }: ScriptsProps) => {
               level: 2,
             };
             const map = new kakao.maps.Map(mapContainer.current, options);
-            const imageSrc = '/svg/marker.svg';
+            const imageSrc = getSelectedImg(shopInfo?.place_name);
             const imageSize = new kakao.maps.Size(32, 32);
             const imageOption = { offset: new kakao.maps.Point(20, 20) };
             const markerImage = new kakao.maps.MarkerImage(

--- a/src/components/wish/FavoriteButton.tsx
+++ b/src/components/wish/FavoriteButton.tsx
@@ -13,7 +13,7 @@ type FavortieButtonProps = {
 };
 
 const FavoriteButton = ({ shopId, isFavorite }: FavortieButtonProps) => {
-  const { mutate: del, isSuccess, isError } = useDeleteFavorite();
+  const { mutate: del, isSuccess, isError } = useDeleteFavorite('/shopDetail');
   const { mutate: add } = usePostFavorite();
 
   const [isModal, setIsModal] = useState<boolean>(false);

--- a/src/components/wish/WishItem.tsx
+++ b/src/components/wish/WishItem.tsx
@@ -13,7 +13,7 @@ const WishItem = ({ shop }: Favorite) => {
   const [isModal, setIsModal] = useState<boolean>(false);
   const [isLogin, setIsLogin] = useState<boolean>(false);
   const [toast, setToast] = useState<boolean>(false);
-  const { mutate: del, isSuccess, isError } = useDeleteFavorite();
+  const { mutate: del, isSuccess, isError } = useDeleteFavorite('/wish');
   const { mutate: add } = usePostFavorite();
 
   const handleAddFavorite = (shopId: number) => {

--- a/src/hooks/mutations/useDeleteFavorite.ts
+++ b/src/hooks/mutations/useDeleteFavorite.ts
@@ -25,7 +25,7 @@ const Querykey = {
   },
 };
 
-export const useDeleteFavorite = (path: any) => {
+export const useDeleteFavorite = (path: string) => {
   return useMutation<void, void, number, unknown>(
     'useDeleteFavorite',
     (shopId: number) => favoriteApi.delFavorites(shopId),
@@ -35,13 +35,13 @@ export const useDeleteFavorite = (path: any) => {
         const previousValue = queryClient.getQueryData([
           Querykey[path].queryKey,
         ]);
-        queryClient.setQueriesData([Querykey[path].queryKey], (old: any) =>
+        queryClient.setQueryData([Querykey[path].queryKey], (old: any) =>
           Querykey[path].convertFunc(old, shopId),
         );
         return { previousValue };
       },
       onError: (context: any) => {
-        queryClient.setQueriesData(
+        queryClient.setQueryData(
           [Querykey[path].queryKey],
           context.previousValue,
         );

--- a/src/hooks/mutations/useDeleteFavorite.ts
+++ b/src/hooks/mutations/useDeleteFavorite.ts
@@ -2,19 +2,54 @@ import favoriteApi from '@apis/favorite/favoriteApi';
 import { queryClient } from 'pages/_app';
 import { useMutation } from 'react-query';
 
-export const useDeleteFavorite = () => {
+const Querykey = {
+  '/wish': {
+    queryKey: 'useGetFavorites',
+    convertFunc: (old: any, shopId: number) =>
+      old.filter((t) => t.shop.id !== shopId),
+  },
+  '/home': {
+    queryKey: 'useGetShopDetail',
+    convertFunc: () => {
+      return;
+    },
+  },
+  '/shopDetail': {
+    queryKey: 'useGetShopDetail',
+    convertFunc: (old) => {
+      return {
+        ...old,
+        favorite: false,
+      };
+    },
+  },
+};
+
+export const useDeleteFavorite = (path: any) => {
   return useMutation<void, void, number, unknown>(
+    'useDeleteFavorite',
     (shopId: number) => favoriteApi.delFavorites(shopId),
     {
-      onSuccess: () => {
-        setTimeout(() => {
-          queryClient.invalidateQueries({
-            queryKey: ['useGetFavorites'],
-          });
-          queryClient.invalidateQueries({
-            queryKey: ['useGetShopDetail'],
-          });
-        }, 1000);
+      onMutate: async (shopId) => {
+        await queryClient.cancelQueries({ queryKey: ['useDeleteFavorite'] });
+        const previousValue = queryClient.getQueryData([
+          Querykey[path].queryKey,
+        ]);
+        queryClient.setQueriesData([Querykey[path].queryKey], (old: any) =>
+          Querykey[path].convertFunc(old, shopId),
+        );
+        return { previousValue };
+      },
+      onError: (context: any) => {
+        queryClient.setQueriesData(
+          [Querykey[path].queryKey],
+          context.previousValue,
+        );
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({
+          queryKey: [Querykey[path].queryKey],
+        });
       },
     },
   );

--- a/src/hooks/mutations/usePostFavorite.ts
+++ b/src/hooks/mutations/usePostFavorite.ts
@@ -4,14 +4,26 @@ import { useMutation } from 'react-query';
 
 export const usePostFavorite = () => {
   return useMutation<void, void, number, unknown>(
+    'usePostFavorite',
     (shopId: number) => favoriteApi.postFavorites(shopId),
     {
-      onSuccess: () => {
-        queryClient.invalidateQueries({
-          queryKey: ['useGetFavorites'],
+      onMutate: async () => {
+        await queryClient.cancelQueries('usePostFavorite');
+        const previousValue = queryClient.getQueryData(['useGetShopDetail']);
+        queryClient.setQueryData('useGetShopDetail', (old: any) => {
+          return {
+            ...old,
+            favorite: true,
+          };
         });
+        return { previousValue };
+      },
+      onError: (context: any) => {
+        queryClient.setQueryData('useGetShopDetail', context.previousValue);
+      },
+      onSettled: () => {
         queryClient.invalidateQueries({
-          queryKey: ['useGetShopDetail'],
+          queryKey: 'useGetShopDetail',
         });
       },
     },

--- a/src/hooks/queries/useGetShop.ts
+++ b/src/hooks/queries/useGetShop.ts
@@ -5,7 +5,7 @@ import { useQuery } from 'react-query';
 
 export const useGetShopDetail = (shopId: number, distance: string) => {
   return useQuery<ShopDetail, Error>(
-    ['useGetShopDetail'],
+    ['useGetShopDetail', shopId],
     () => shopApi.getShopDetail(shopId, distance),
     {
       retry: false,

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,14 +1,18 @@
+import { useEffect, useState } from 'react';
+import { useGetShopsInRad } from '@hooks/queries/useGetShop';
+import { getToken } from '@utils/token';
 import NavBar from '@components/common/NavBar';
 import PageLayout from '@components/layout/PageLayout';
 import Category from '@components/home/Category';
 import ResearchButton from '@components/home/ResearchButton';
 import TrackerButton from '@components/home/TrackerButton';
 import ShopModal from '@components/home/ShopModal';
-import { useEffect, useState } from 'react';
-import { useGetShopsInRad } from '@hooks/queries/useGetShop';
 import Map from '@components/common/Map';
+import Modal from '@components/common/Modal';
 
 const Home = () => {
+  const [isLogin, setIsLogin] = useState<boolean>(false);
+  const [isModal, setIsModal] = useState<boolean>(false);
   const [brd, setBrd] = useState<string>('');
   const [modalProps, setModalProps] = useState<Shop>();
   const [shopsInfo, setShopsInfo] = useState<Shop[]>();
@@ -28,17 +32,15 @@ const Home = () => {
 
   const { data: shopInfo } = useGetShopsInRad(location.lat, location.lng, brd);
 
-  const [isFavorite, setIsFavorite] = useState<boolean | undefined>(
-    modalProps?.favorite,
-  );
+  useEffect(() => {
+    if (getToken().accessToken) {
+      setIsLogin(true);
+    }
+  }, []);
 
   useEffect(() => {
     setShopsInfo(shopInfo);
   }, [shopInfo]);
-
-  useEffect(() => {
-    setIsFavorite(modalProps?.favorite);
-  }, [modalProps]);
 
   const handleTracker = () => {
     const { kakao } = window;
@@ -57,6 +59,16 @@ const Home = () => {
 
   return (
     <PageLayout>
+      {isModal && (
+        <Modal
+          isModal={isModal}
+          isKakao={true}
+          title="로그인 상태가 아니에요!"
+          message="해당 기능은 카카오톡 로그인을 하셔야 이용가능한 기능이에요. 로그인 하시겠어요?"
+          left="아니요"
+          leftEvent={() => setIsModal(false)}
+        />
+      )}
       <NavBar
         area="지도 지역명"
         isRight={true}
@@ -87,10 +99,9 @@ const Home = () => {
             distance={modalProps.distance}
             star_rating_avg={modalProps.star_rating_avg}
             review_cnt={modalProps.review_cnt}
-            favorite={modalProps.favorite}
             favorite_cnt={modalProps.favorite_cnt}
-            isFavorite={isFavorite}
-            setIsFavorite={setIsFavorite}
+            isLogin={isLogin}
+            setIsModal={setIsModal}
           />
         )}
       </div>

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -75,7 +75,7 @@ const Home = () => {
         location={curPos}
         setShopsInfo={setShopsInfo}
       />
-      <div className="relative z-10">
+      <div className="fixed z-10">
         <Category setBrd={setBrd} />
         {location.lat !== mapPos.lat &&
           location.lng !== mapPos.lng &&

--- a/src/utils/getImgSrc.ts
+++ b/src/utils/getImgSrc.ts
@@ -1,24 +1,24 @@
 export const getSelectedImg = (name: string) => {
-  const src = name.includes('인생네컷')
+  const src = name?.includes('인생네컷')
     ? '/svg/marker_select_pink.svg'
-    : name.includes('하루필름')
+    : name?.includes('하루필름')
     ? '/svg/marker_select_blue.svg'
-    : name.includes('포토이즘')
+    : name?.includes('포토이즘')
     ? '/svg/marker_select_black.svg'
-    : name.includes('포토그레이')
+    : name?.includes('포토그레이')
     ? '/svg/marker_select_gray.svg'
     : '/svg/marker_select_white.svg';
   return src;
 };
 
 export const getDefaultImg = (name: string) => {
-  const src = name.includes('인생네컷')
+  const src = name?.includes('인생네컷')
     ? '/svg/marker_pink.svg'
-    : name.includes('하루필름')
+    : name?.includes('하루필름')
     ? '/svg/marker_blue.svg'
-    : name.includes('포토이즘')
+    : name?.includes('포토이즘')
     ? '/svg/marker_black.svg'
-    : name.includes('포토그레이')
+    : name?.includes('포토그레이')
     ? '/svg/marker_gray.svg'
     : '/svg/marker_white.svg';
   return src;


### PR DESCRIPTION
## 🛠 작업 내용

close #84 

- shopModal 컴포넌트로 전달하는 해당 지점 id를 통해 useGetShopDetail을 커스텀 훅을 사용합니다.
- 해당 커스텀 훅을 통해 받은 지점 데이터의 favorite을 가지고 찜, 찜 취소를 합니다.
- 찜, 찜 취소후에는 캐시 무효화를 합니다.
- 찜이 사용되는 페이지와 해당 페이지에서 무효화 할 캐시가 달라 path에 따른 낙관적 업데이트를 구현했습니다.
- home 페이지에서 로그인 상태를 확인하고 shopModal에서 찜버튼을 누르면 비로그인 시 모달을 보여줍니다.
- 지점 상세 페이지에서 지점 종류에 따라 마커를 보여주도록 util함수를 사용했습니다.

## 📸 스크린샷 or GIF

https://user-images.githubusercontent.com/79186378/233841568-5cf1b722-5ee7-481b-b9e8-95975c66fce9.mov

https://user-images.githubusercontent.com/79186378/233841549-ab29a74d-2b15-44df-abcb-a4ed3549199c.mov

