### PR TITLE
fix: #86/ 지점 상세페이지 새로고침 시 지도 불러오지 못하는 현상 수정

### DIFF
--- a/src/components/home/ShopModal.tsx
+++ b/src/components/home/ShopModal.tsx
@@ -13,7 +13,6 @@ type ShopModalProps = {
   distance: string;
   star_rating_avg: number;
   review_cnt: number;
-  favorite_cnt: number;
   isLogin: boolean;
   setIsModal: Dispatch<SetStateAction<boolean>>;
 };
@@ -24,7 +23,6 @@ const ShopModal = ({
   distance,
   star_rating_avg,
   review_cnt,
-  favorite_cnt,
   isLogin,
   setIsModal,
 }: ShopModalProps) => {
@@ -88,7 +86,7 @@ const ShopModal = ({
             </span>
             <div className="border-l pl-2">
               <span className="pr-1">찜</span>
-              <span className="font-semibold">{favorite_cnt}</span>
+              <span className="font-semibold">{shopInfo?.favorite_cnt}</span>
             </div>
           </div>
           <span>{distance}</span>

--- a/src/components/navbar/SearchResult.tsx
+++ b/src/components/navbar/SearchResult.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import tw from 'tailwind-styled-components';
 
 type SearchProps = Shop & {
@@ -9,16 +10,23 @@ type SearchProps = Shop & {
 const SearchResult = ({
   isTyping,
   value,
+  id,
   place_name,
   distance,
   road_address_name,
 }: SearchProps) => {
+  const router = useRouter();
   const parts = place_name.split(value);
   return isTyping ? (
     <li className="cursor-pointer bg-white px-3 first:pt-5">
       <DivisionBar />
       {
-        <div className="flex items-center">
+        <div
+          className="flex items-center"
+          onClick={() =>
+            router.push(`/shopDetail/?shopId=${id}&distance=${distance}`)
+          }
+        >
           <div className="flex flex-col items-center">
             <Image
               src="/svg/navbar/location.svg"

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -99,7 +99,6 @@ const Home = () => {
             distance={modalProps.distance}
             star_rating_avg={modalProps.star_rating_avg}
             review_cnt={modalProps.review_cnt}
-            favorite_cnt={modalProps.favorite_cnt}
             isLogin={isLogin}
             setIsModal={setIsModal}
           />

--- a/src/pages/shopDetail/index.tsx
+++ b/src/pages/shopDetail/index.tsx
@@ -1,10 +1,11 @@
 import Image from 'next/image';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { QueryClient, dehydrate } from 'react-query';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import { useGetShopDetail } from '@hooks/queries/useGetShop';
 import { useGetAllShopReviews } from '@hooks/queries/useGetReview';
+import { CONFIG } from '@config';
 import shopApi from '@apis/shop/shopApi';
 import NavBar from '@components/common/NavBar';
 import ShopLayout from '@components/layout/ShopLayout';
@@ -12,28 +13,28 @@ import ReviewItem from '@components/common/ReviewItem';
 import StarRate from '@components/common/StarRate';
 import tw from 'tailwind-styled-components';
 import Button from '@components/common/Button';
-import Scripts from '@components/common/Scripts';
 import BrandTag from '@components/common/BrandTag';
+import Scripts from '@components/common/Scripts';
 
 const ShopDetail = ({ shopId, distance }) => {
   const router = useRouter();
+  const mapContainer = useRef<HTMLDivElement>(null);
 
   const [reviewLoaded, setReviewLoaded] = useState<boolean>(false);
-  const mapContainer = useRef<HTMLDivElement>(null);
 
   const { data: shopInfo } = useGetShopDetail(shopId, distance);
   const { data: additionalReview } = useGetAllShopReviews(shopId);
 
   return (
     <ShopLayout className="bg-white pt-[62px]">
-      <Scripts shopInfo={shopInfo as ShopDetail} mapContainer={mapContainer} />
+      {shopInfo && <Scripts shopInfo={shopInfo} mapContainer={mapContainer} />}
+      <Map ref={mapContainer}></Map>
       <NavBar
         isLeft={true}
         isDetail={true}
         shopId={shopInfo?.id}
         isFavorite={shopInfo?.favorite}
       />
-      <div className="h-[270px] w-full pt-[62px]" ref={mapContainer}></div>
       <ShopInfoBox>
         <ShopTagBox>
           <BrandTag name={shopInfo?.place_name as string} />
@@ -45,7 +46,7 @@ const ShopDetail = ({ shopId, distance }) => {
             <div className="pl-1 pr-2">
               {shopInfo?.star_rating_avg} ({shopInfo?.review_cnt})
             </div>
-            <div className="px-2 border-l border-text-alternative">
+            <div className="border-l border-text-alternative px-2">
               <span>찜</span>
               <span className="pl-1 font-semibold">
                 {shopInfo?.favorite_cnt}
@@ -121,6 +122,9 @@ const ShopDetail = ({ shopId, distance }) => {
   );
 };
 
+const Map = tw.div`
+h-[270px] w-full pt-[62px]
+`;
 const ShopInfoBox = tw.div`
 flex flex-col px-4 pt-4 pb-2 mb-[52px]
 `;


### PR DESCRIPTION
## 🛠 작업 내용

close #86 

- 지점 상세페이지 새로고침 시 지도 불러오지 못하는 현상을 수정했습니다.
- 홈페이지에서 ShopModal 컴포넌트 내 찜, 찜 취소 시 찜 수 반영되지 않는 현상 수정했습니다.
- 검색 결과 클릭 시 지점 상세 페이지로 이동하도록 수정했습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
