### PR TITLE
refactor: #98/ api 타입 수정사항 반영

### DIFF
--- a/src/apis/favorite/favorite.d.ts
+++ b/src/apis/favorite/favorite.d.ts
@@ -3,7 +3,6 @@ type Favorite = {
   shop: {
     id: number;
     place_name: string;
-    road_address_name: string;
     distance: string;
     star_rating_avg: number;
     review_cnt: number;

--- a/src/apis/favorite/favoriteApi.ts
+++ b/src/apis/favorite/favoriteApi.ts
@@ -1,9 +1,9 @@
 import instance from '@apis/instance';
 
 class FavoriteApi {
-  getAllFavorites = async (lng: number, lat: number): Promise<Favorite[]> => {
+  getAllFavorites = async (lat: number, lng: number): Promise<Favorite[]> => {
     const { data } = await instance.get(
-      `/favorites?longitude=${lng}&latitude=${lat}`,
+      `/favorites?userLat=${lat}&userLng=${lng}`,
     );
     return data;
   };

--- a/src/apis/shop/shop.d.ts
+++ b/src/apis/shop/shop.d.ts
@@ -1,10 +1,13 @@
 type Shop = ShopProps & {
-  favorite_cnt: number;
-  brand: BrandProps[];
+  place_address: string;
+};
+
+type ShopInRad = ShopProps & {
+  address: string;
+  shops: ShopProps[];
 };
 
 type ShopDetail = ShopProps & {
-  road_address_name: string;
   recent_reviews: ShopReviewProps[];
 };
 
@@ -18,8 +21,8 @@ type ShopProps = {
   star_rating_avg: number;
   review_cnt: number;
   favorite_cnt: number;
+  brand?: BrandProps;
   favorite: boolean;
-  road_address_name?: string;
 };
 
 type ShopReviewProps = {

--- a/src/apis/shop/shopApi.ts
+++ b/src/apis/shop/shopApi.ts
@@ -7,7 +7,7 @@ class ShopApi {
     lng: number,
   ): Promise<Shop[]> => {
     const { data } = await instance.get(
-      `/shops?keyword=${keyword}&latitude=${lat}&longitude=${lng}`,
+      `/shops?keyword=${keyword}&userLat=${lat}&userLng=${lng}`,
     );
     return data;
   };
@@ -15,10 +15,12 @@ class ShopApi {
   getShopsInRad = async (
     lat: number,
     lng: number,
+    mapLat: number,
+    mapLng: number,
     brd?: string,
-  ): Promise<Shop[]> => {
+  ): Promise<ShopInRad> => {
     const { data } = await instance.get(
-      `/shops/brand?latitude=${lat}&longitude=${lng}&brand=${brd}`,
+      `/shops/brand?userLat=${lat}&userLng=${lng}&mapLat=${mapLat}&mapLng=${mapLng}&brand=${brd}`,
     );
     return data;
   };

--- a/src/components/common/Map.tsx
+++ b/src/components/common/Map.tsx
@@ -8,10 +8,10 @@ type Position = {
 };
 
 type MapProps = {
-  shopInfo: Shop[] | undefined;
+  shopInfo: ShopProps[] | undefined;
   kakaoMap: any;
   setKakaoMap: Dispatch<SetStateAction<any>>;
-  setModalProps: Dispatch<SetStateAction<Shop | undefined>>;
+  setModalProps: Dispatch<SetStateAction<ShopProps | undefined>>;
   setLocation: Dispatch<SetStateAction<Position>>;
   setMapPos: Dispatch<SetStateAction<Position>>;
   setCurPos: Dispatch<SetStateAction<Position>>;

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -14,7 +14,7 @@ type NavBarProps = {
   shopId?: number;
   isFavorite?: boolean;
   location?: Position;
-  setShopsInfo?: Dispatch<SetStateAction<Shop[] | undefined>>;
+  setShopsInfo?: Dispatch<SetStateAction<ShopProps[] | undefined>>;
 };
 
 const NavBar = ({
@@ -58,7 +58,7 @@ const NavBar = ({
             {isMap && (
               <>
                 <div
-                  className="flex flex-col items-center ml-1"
+                  className="ml-1 flex flex-col items-center"
                   onClick={() => {
                     setIsMap(false);
                     setIsList(true);
@@ -78,7 +78,7 @@ const NavBar = ({
             {isList && setShopsInfo && (
               <>
                 <div
-                  className="flex flex-col items-center ml-1"
+                  className="ml-1 flex flex-col items-center"
                   onClick={() => {
                     setIsList(false);
                     setIsMap(true);

--- a/src/hooks/queries/useGetFavorite.ts
+++ b/src/hooks/queries/useGetFavorite.ts
@@ -1,13 +1,14 @@
 import favoriteApi from '@apis/favorite/favoriteApi';
 import { useQuery } from 'react-query';
 
-export const useGetFavorite = (lng: number, lat: number) => {
+export const useGetFavorite = (lat: number, lng: number) => {
   return useQuery<Favorite[], Error>(
     ['useGetFavorites'],
-    () => favoriteApi.getAllFavorites(lng, lat),
+    () => favoriteApi.getAllFavorites(lat, lng),
     {
       retry: false,
       refetchOnWindowFocus: false,
+      enabled: !!lat,
     },
   );
 };

--- a/src/hooks/queries/useGetShop.ts
+++ b/src/hooks/queries/useGetShop.ts
@@ -15,23 +15,19 @@ export const useGetShopDetail = (shopId: number, distance: string) => {
   );
 };
 
-export const useGetShopsInRad = (lat: number, lng: number, brd?: string) => {
-  return useQuery<Shop[], Error>(
-    ['useGetShopsInRad', brd, lat, lng],
-    () => shopApi.getShopsInRad(lat, lng, brd),
+export const useGetShopsInRad = (
+  lat: number,
+  lng: number,
+  mapLat: number,
+  mapLng: number,
+  brd?: string,
+) => {
+  return useQuery<ShopInRad, Error>(
+    ['useGetShopsInRad', brd, mapLat, mapLng],
+    () => shopApi.getShopsInRad(lat, lng, mapLat, mapLng, brd),
     {
       refetchOnWindowFocus: false,
       enabled: !!lat,
-      select: (shops) => {
-        if (brd) {
-          const selected = shops.filter((shops) =>
-            shops.place_name.includes(brd),
-          );
-          return selected;
-        } else {
-          return shops;
-        }
-      },
     },
   );
 };

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -14,8 +14,8 @@ const Home = () => {
   const [isLogin, setIsLogin] = useState<boolean>(false);
   const [isModal, setIsModal] = useState<boolean>(false);
   const [brd, setBrd] = useState<string>('');
-  const [modalProps, setModalProps] = useState<Shop>();
-  const [shopsInfo, setShopsInfo] = useState<Shop[]>();
+  const [modalProps, setModalProps] = useState<ShopProps>();
+  const [shopsInfo, setShopsInfo] = useState<ShopProps[]>();
   const [kakaoMap, setKakaoMap] = useState<any>(null);
   const [curPos, setCurPos] = useState<Position>({
     lat: 0,
@@ -30,7 +30,13 @@ const Home = () => {
     lng: 0,
   });
 
-  const { data: shopInfo } = useGetShopsInRad(location.lat, location.lng, brd);
+  const { data: shopInfo } = useGetShopsInRad(
+    curPos.lat,
+    curPos.lng,
+    location.lat,
+    location.lng,
+    brd,
+  );
 
   useEffect(() => {
     if (getToken().accessToken) {
@@ -39,7 +45,7 @@ const Home = () => {
   }, []);
 
   useEffect(() => {
-    setShopsInfo(shopInfo);
+    setShopsInfo(shopInfo?.shops);
   }, [shopInfo]);
 
   const handleTracker = () => {
@@ -56,7 +62,7 @@ const Home = () => {
     const { Ma, La } = kakaoMap.getCenter();
     setLocation({ lat: Ma, lng: La });
   };
-
+  console.log(location);
   return (
     <PageLayout>
       {isModal && (

--- a/src/pages/wish/index.tsx
+++ b/src/pages/wish/index.tsx
@@ -2,10 +2,18 @@ import NavBar from '@components/common/NavBar';
 import PageLayout from '@components/layout/PageLayout';
 import WishItem from '@components/wish/WishItem';
 import { useGetFavorite } from '@hooks/queries/useGetFavorite';
+import { useEffect, useState } from 'react';
 import tw from 'tailwind-styled-components';
 
 const Wish = () => {
-  const { data: favorites } = useGetFavorite(127.052068, 37.545704);
+  const [location, setLocation] = useState<Position>({ lat: 0, lng: 0 });
+  useEffect(() => {
+    navigator.geolocation.getCurrentPosition(({ coords }) => {
+      const { latitude, longitude } = coords;
+      setLocation({ lat: latitude, lng: longitude });
+    });
+  }, []);
+  const { data: favorites } = useGetFavorite(location.lat, location.lng);
   return (
     <PageLayout>
       <NavBar leftTitle={'찜 목록'} />


### PR DESCRIPTION
## 🛠 작업 내용

close #98 

- 깃북에 반영된 대로 api 타입 수정사항 반영했습니다.
- 추가적인 파라미터 전달하여 지점과 떨어진 거리를 현재 위치 기반으로 받도록 합니다.
- 찜 목록 불러오기 api에 임의로 전달하던 위도, 경도를 geolocation API 기반으로 불러온 현재위치를 전달합니다.
- 위치가 자주 사용됨에 따라 geolocation API의 반복적인 사용으로 추후에 현재위치는 클라이언트 state로 관리하면 좋을것같습니다.
- 지도 지역명은 pull 하시고 작업하시면 될것같습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
