### PR TITLE
refactor: #104/지도 로딩 중일 때 지도지역명 안 보이게 수정

### DIFF
--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -58,7 +58,7 @@ const NavBar = ({
             {isMap && (
               <>
                 <div
-                  className="flex flex-col items-center ml-1"
+                  className="ml-1 flex flex-col items-center"
                   onClick={() => {
                     setIsMap(false);
                     setIsList(true);
@@ -78,7 +78,7 @@ const NavBar = ({
             {isList && setShopsInfo && (
               <>
                 <div
-                  className="flex flex-col items-center ml-1"
+                  className="ml-1 flex flex-col items-center"
                   onClick={() => {
                     setIsList(false);
                     setIsMap(true);
@@ -123,7 +123,10 @@ const NavBar = ({
             />
           </>
         )}
-        {leftTitle && !isInput ? (
+        {leftTitle &&
+        !isInput &&
+        location?.lat !== 33.450701 &&
+        location?.lng !== 126.570667 ? (
           <LeftTitle>{leftTitle}</LeftTitle>
         ) : (
           <div></div>


### PR DESCRIPTION
## 🛠 작업 내용

지도 로딩 중일 때 지도지역명 안 보이게 수정
- close #104

## PR 세부 내용

<!--수정/추가한 작업 내용을 설명해주세요.-->
저번 PR에 같이 올렸어야 했던 사항이지만, 지도 로딩 중일 때 기본 중심 좌표인 제주특별자치도 ~~ 로 나와서 이를 `location?.lat !== 33.450701 && location?.lng !== 126.570667`일 때 지도지역명이 안 보이게 처리하였습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
