### PR TITLE
feat: #92/ 내주변 페이지 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    domains: ['d18tllc1sxg8cp.cloudfront.net'],
+  },
   async redirects() {
     return [
       {

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -33,9 +33,11 @@ instance.interceptors.response.use(
     const { data } = response;
     const UnAuthorizeError = data.error_code === '100';
     const InvalidTokenError = data.error_code === '101';
-    const ExpiredTokenError = data.error_code === '102';
-    const RefreshTokenError = data.error_code === '103';
-    if (UnAuthorizeError) {
+    const ExpiredAccessTokenError = data.error_code === '102';
+    const ExpiredRefreshTokenError = data.error_code === '103';
+    const RefreshTokenError = data.error_code === '104';
+
+    if (ExpiredRefreshTokenError || RefreshTokenError) {
       alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
       if (CONFIG.ENV === 'development') {
         window.location.href = `${CONFIG.LOCAL}/auth/login`;
@@ -43,7 +45,7 @@ instance.interceptors.response.use(
         window.location.href = `${CONFIG.DOMAIN}/auth/login`;
       }
     }
-    if (InvalidTokenError || RefreshTokenError) {
+    if (UnAuthorizeError || InvalidTokenError) {
       alert('유효하지 않은 토큰입니다. 다시 로그인해 주시기 바랍니다.');
       if (CONFIG.ENV === 'development') {
         window.location.href = `${CONFIG.LOCAL}/auth/login`;
@@ -51,7 +53,7 @@ instance.interceptors.response.use(
         window.location.href = `${CONFIG.DOMAIN}/auth/login`;
       }
     }
-    if (ExpiredTokenError) {
+    if (ExpiredAccessTokenError) {
       const accessToken = await ReissueToken();
       setToken({
         accessToken,

--- a/src/components/common/LocationMap.tsx
+++ b/src/components/common/LocationMap.tsx
@@ -1,0 +1,125 @@
+import { useState, useEffect, useRef, SetStateAction, Dispatch } from 'react';
+import { CONFIG } from '@config';
+
+type Position = {
+  lat: number;
+  lng: number;
+};
+
+type MapProps = {
+  shopInfo: ShopProps[] | undefined;
+  kakaoMap: any;
+  setKakaoMap: Dispatch<SetStateAction<any>>;
+  setLocation: Dispatch<SetStateAction<Position>>;
+  setMapPos: Dispatch<SetStateAction<Position>>;
+  setCurPos: Dispatch<SetStateAction<Position>>;
+};
+
+const LocationMap = ({
+  shopInfo,
+  kakaoMap,
+  setKakaoMap,
+  setLocation,
+  setMapPos,
+  setCurPos,
+}: MapProps) => {
+  const mapContainer = useRef<HTMLDivElement>(null);
+  const [markers, setMarkers] = useState<any[]>([]);
+  const [isLoaded, setIsLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    const $script = document.createElement('script');
+    $script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${CONFIG.API_KEYS.MAP}&autoload=false&libraries=services`;
+    document.head.appendChild($script);
+    $script.onload = () => {
+      setIsLoaded(true);
+    };
+    if (isLoaded) {
+      const { kakao } = window;
+      window.kakao.maps.load(() => {
+        const mapOption = {
+          center: new kakao.maps.LatLng(33.450701, 126.570667),
+          level: 3,
+        };
+        const map = new kakao.maps.Map(mapContainer.current, mapOption);
+        setLocation({ lat: 33.450701, lng: 126.570667 });
+        setMapPos({ lat: 33.450701, lng: 126.570667 });
+        setCurPos({ lat: 33.450701, lng: 126.570667 });
+        setKakaoMap(map);
+        if (navigator.geolocation) {
+          navigator.geolocation.getCurrentPosition(({ coords }) => {
+            const { latitude, longitude } = coords;
+            setLocation({ lat: latitude, lng: longitude });
+            setMapPos({ lat: latitude, lng: longitude });
+            setCurPos({ lat: latitude, lng: longitude });
+            const locPosition = new kakao.maps.LatLng(latitude, longitude);
+            const imageSrc = '/svg/home/tracking.svg';
+            const imageSize = new kakao.maps.Size(32, 32);
+            const imageOption = { offset: new kakao.maps.Point(20, 20) };
+            const markerPosition = new kakao.maps.LatLng(latitude, longitude);
+            const markerImage = new kakao.maps.MarkerImage(
+              imageSrc,
+              imageSize,
+              imageOption,
+            );
+            const marker = new kakao.maps.Marker({
+              position: markerPosition,
+              image: markerImage,
+            });
+            marker.setMap(map);
+            map.setCenter(locPosition);
+          });
+        }
+      });
+    }
+  }, [isLoaded]);
+
+  useEffect(() => {
+    if (shopInfo && kakaoMap) {
+      const { kakao } = window;
+      kakao.maps.event.addListener(kakaoMap, 'dragend', () => {
+        const { Ma, La } = kakaoMap.getCenter();
+        setMapPos({ lat: Ma, lng: La });
+      });
+      if (markers.length) {
+        markers.forEach((marker) => marker.setMap(null));
+      }
+      const imageSize = new kakao.maps.Size(35, 35);
+      const imageOption = {
+        offset: new kakao.maps.Point(20, 30),
+      };
+      setMarkers(() => {
+        return shopInfo.map((shop) => {
+          const position = new kakao.maps.LatLng(
+            Number(shop.latitude),
+            Number(shop.longitude),
+          );
+          const normalImageSrc = '/svg/marker.svg';
+          const normalImage = new kakao.maps.MarkerImage(
+            normalImageSrc,
+            imageSize,
+            imageOption,
+          );
+          const marker = new kakao.maps.Marker({
+            map: kakaoMap,
+            position: position,
+            image: normalImage,
+            clickable: true,
+          });
+          return marker;
+        });
+      });
+    }
+  }, [shopInfo, kakaoMap]);
+
+  return (
+    <>
+      <div
+        className="absolute top-0 z-0 h-[500px] w-full max-w-[375px]"
+        ref={mapContainer}
+      ></div>
+    </>
+  );
+};
+
+export default LocationMap;

--- a/src/components/home/Category.tsx
+++ b/src/components/home/Category.tsx
@@ -1,8 +1,7 @@
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 import tw from 'tailwind-styled-components';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
-import styles from '@styles/swiper.module.css';
 
 type CategoriesProps = {
   id: number;
@@ -12,6 +11,7 @@ type CategoriesProps = {
 
 type CategoryData = {
   setBrd: Dispatch<SetStateAction<string>>;
+  className?: React.ComponentProps<'div'>['className'];
 };
 
 const Categories: CategoriesProps[] = [
@@ -22,7 +22,7 @@ const Categories: CategoriesProps[] = [
   { id: 5, name: '포토그레이', state: '포토그레이' },
 ];
 
-const Category = ({ setBrd }: CategoryData) => {
+const Category = ({ setBrd, ...rest }: CategoryData) => {
   const [categoryId, setCategoryId] = useState<number>(1);
   const [swiper, setSwiper] = useState<any>(null);
 
@@ -38,12 +38,12 @@ const Category = ({ setBrd }: CategoryData) => {
   };
 
   return (
-    <CategoryBar>
+    <CategoryBar {...rest}>
       <ItemsWrapper>
         <Swiper
           scrollbar={{ draggable: true }}
           slidesPerView={4}
-          spaceBetween={16}
+          spaceBetween={12}
           onSwiper={handleSwiper}
         >
           {Categories.map(({ id, name, state }) => (
@@ -73,7 +73,7 @@ mt-[68px] overflow-x-hidden fixed max-w-[375px] relative
 `;
 
 const ItemsWrapper = tw.ul`
-flex items-center pl-[16px] my-[8px] 
+flex items-center pl-[16px] my-[8px]
 `;
 
 const Item = tw.li`

--- a/src/components/location/ShopItem.tsx
+++ b/src/components/location/ShopItem.tsx
@@ -1,0 +1,120 @@
+import tw from 'tailwind-styled-components';
+import Image from 'next/image';
+import BrandTag from '@components/common/BrandTag';
+import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
+import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
+import { useRouter } from 'next/router';
+import { useGetShopDetail } from '@hooks/queries/useGetShop';
+import { Dispatch, SetStateAction } from 'react';
+
+type ShopItemProps = {
+  brand_name: string;
+  file_path: string;
+  distance: string;
+  id: number;
+  place_name: string;
+  star_rating: number;
+  review_cnt: number;
+  isLogin: boolean;
+  setIsModal: Dispatch<SetStateAction<boolean>>;
+};
+
+const ShopItem = ({
+  brand_name,
+  file_path,
+  distance,
+  id,
+  place_name,
+  star_rating,
+  review_cnt,
+  isLogin,
+  setIsModal,
+}: ShopItemProps) => {
+  const { data: shopInfo } = useGetShopDetail(id, distance);
+  const { mutate: add } = usePostFavorite();
+  const { mutate: del } = useDeleteFavorite('/home');
+  const router = useRouter();
+  const handleFavorite = (
+    e: React.MouseEvent<HTMLImageElement, MouseEvent>,
+    id: number,
+  ) => {
+    e.stopPropagation();
+    if (!isLogin) {
+      setIsModal(true);
+    } else {
+      if (shopInfo?.favorite) {
+        del(id);
+      } else {
+        add(id);
+      }
+    }
+  };
+  return (
+    <ItemContainer
+      onClick={() => {
+        router.push(`/shopDetail?shopId=${id}&distance=${distance}`);
+      }}
+    >
+      <ItemImgContainer>
+        <Image
+          className="rounded-lg"
+          src={`${file_path}`}
+          alt={brand_name}
+          fill
+        />
+        <FavoriteBtn>
+          {shopInfo?.favorite ? (
+            <Image
+              src="/svg/wish/filled-bookmark.svg"
+              width={24}
+              height={24}
+              alt="wish"
+              onClick={(e) => {
+                handleFavorite(e, id);
+              }}
+            />
+          ) : (
+            <Image
+              src="/svg/wish/lined-bookmark.svg"
+              width={24}
+              height={24}
+              alt="wish"
+              className="cursor-pointer"
+              onClick={(e) => handleFavorite(e, id)}
+            />
+          )}
+        </FavoriteBtn>
+      </ItemImgContainer>
+      <span className="truncate text-label1">{place_name}</span>
+      <ItemDescBox>
+        <span className="flex pr-2">
+          <Image src="/svg/star.svg" width={16} height={16} alt="star" />
+          {star_rating} ({review_cnt})
+        </span>
+        <div className="border-l pl-2">
+          <span className="pr-1">찜</span>
+          <span className="font-semibold">{shopInfo?.favorite_cnt}</span>
+        </div>
+      </ItemDescBox>
+      <span className="mb-2 text-caption1 text-text-alternative">
+        {distance}
+      </span>
+      <BrandTag name={brand_name} />
+    </ItemContainer>
+  );
+};
+
+const ItemContainer = tw.div`
+flex flex-col cursor-pointer relative
+`;
+const FavoriteBtn = tw.div`
+absolute top-2 right-2
+`;
+const ItemImgContainer = tw.div`
+mb-3 h-[160px] w-full rounded-lg relative
+`;
+const ItemDescBox = tw.div`
+mt-2 flex text-caption1
+`;
+
+export default ShopItem;

--- a/src/hooks/queries/useGetShop.ts
+++ b/src/hooks/queries/useGetShop.ts
@@ -23,7 +23,7 @@ export const useGetShopsInRad = (
   brd?: string,
 ) => {
   return useQuery<ShopInRad, Error>(
-    ['useGetShopsInRad', brd, mapLat, mapLng],
+    ['useGetShopsInRad', mapLat, mapLng],
     () => shopApi.getShopsInRad(lat, lng, mapLat, mapLng, brd),
     {
       refetchOnWindowFocus: false,

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -45,8 +45,15 @@ const Home = () => {
   }, []);
 
   useEffect(() => {
-    setShopsInfo(shopInfo?.shops);
-  }, [shopInfo]);
+    if (brd) {
+      const brdShops = shopInfo?.shops.filter(
+        (shop) => shop.brand?.brand_name === brd,
+      );
+      setShopsInfo(brdShops);
+    } else {
+      setShopsInfo(shopInfo?.shops);
+    }
+  }, [shopInfo, brd]);
 
   const handleTracker = () => {
     const { kakao } = window;

--- a/src/pages/location/index.tsx
+++ b/src/pages/location/index.tsx
@@ -55,8 +55,6 @@ const Location = () => {
     }
   }, []);
 
-  console.log(shopsInfo);
-
   const handleTracker = () => {
     const { kakao } = window;
     const moveLatLng = new kakao.maps.LatLng(curPos.lat, curPos.lng);

--- a/src/pages/location/index.tsx
+++ b/src/pages/location/index.tsx
@@ -1,13 +1,142 @@
+import tw from 'tailwind-styled-components';
 import NavBar from '@components/common/NavBar';
 import PageLayout from '@components/layout/PageLayout';
+import { useState, useEffect } from 'react';
+import { useGetShopsInRad } from '@hooks/queries/useGetShop';
+import LocationMap from '@components/common/LocationMap';
+import TrackerButton from '@components/home/TrackerButton';
+import Image from 'next/image';
+import ShopItem from '@components/location/ShopItem';
+import Category from '@components/home/Category';
+import { getToken } from '@utils/token';
+import Modal from '@components/common/Modal';
 
 const Location = () => {
+  const [isLogin, setIsLogin] = useState<boolean>(false);
+  const [isModal, setIsModal] = useState<boolean>(false);
+  const [brd, setBrd] = useState<string>('');
+  const [shopsInfo, setShopsInfo] = useState<ShopProps[]>();
+  const [kakaoMap, setKakaoMap] = useState<any>(null);
+  const [curPos, setCurPos] = useState<Position>({
+    lat: 0,
+    lng: 0,
+  });
+  const [location, setLocation] = useState<Position>({
+    lat: 0,
+    lng: 0,
+  });
+  const [mapPos, setMapPos] = useState<Position>({
+    lat: 0,
+    lng: 0,
+  });
+
+  const { data: shopInfo } = useGetShopsInRad(
+    curPos.lat,
+    curPos.lng,
+    mapPos.lat,
+    mapPos.lng,
+    brd,
+  );
+
+  useEffect(() => {
+    if (brd) {
+      const brdShops = shopInfo?.shops.filter(
+        (shop) => shop.brand?.brand_name === brd,
+      );
+      setShopsInfo(brdShops);
+    } else {
+      setShopsInfo(shopInfo?.shops);
+    }
+  }, [shopInfo, brd]);
+
+  useEffect(() => {
+    if (getToken().accessToken) {
+      setIsLogin(true);
+    }
+  }, []);
+
+  console.log(shopsInfo);
+
+  const handleTracker = () => {
+    const { kakao } = window;
+    const moveLatLng = new kakao.maps.LatLng(curPos.lat, curPos.lng);
+    kakaoMap.setLevel(3);
+    kakaoMap.panTo(moveLatLng);
+    setMapPos({ lat: location.lat, lng: location.lng });
+  };
+  console.log(shopsInfo);
   return (
-    <PageLayout>
-      <NavBar leftTitle="지도 지역명" isRight={true} />
-      Location
+    <PageLayout className="bg-white">
+      {isModal && (
+        <Modal
+          isModal={isModal}
+          isKakao={true}
+          title="로그인 상태가 아니에요!"
+          message="해당 기능은 카카오톡 로그인을 하셔야 이용가능한 기능이에요. 로그인 하시겠어요?"
+          left="아니요"
+          leftEvent={() => setIsModal(false)}
+        />
+      )}
+      <NavBar
+        leftTitle={shopInfo?.address}
+        isRight={true}
+        location={curPos}
+        setShopsInfo={setShopsInfo}
+      />
+      <LocationMap
+        shopInfo={shopsInfo}
+        kakaoMap={kakaoMap}
+        setLocation={setLocation}
+        setKakaoMap={setKakaoMap}
+        setMapPos={setMapPos}
+        setCurPos={setCurPos}
+      />
+      <div className="absolute top-[430px] w-full max-w-[375px] pb-[71px]">
+        <TrackerButton onClick={handleTracker} />
+      </div>
+      <ResultContainer>
+        <ResultBox>
+          <Bar />
+          <Category setBrd={setBrd} className="mt-8" />
+          {shopsInfo?.length === 0 && (
+            <div className="flex h-[250px] items-center justify-center px-4">
+              반경 5km 이내 포토부스가 존재하지 않습니다.
+            </div>
+          )}
+          <ResultItemBox>
+            {shopInfo &&
+              shopsInfo?.map((shop) => (
+                <ShopItem
+                  key={shop.id}
+                  brand_name={shop.brand?.brand_name as string}
+                  file_path={shop.brand?.file_path as string}
+                  distance={shop.distance}
+                  id={shop.id}
+                  place_name={shop.place_name}
+                  star_rating={shop.star_rating_avg}
+                  review_cnt={shop.review_cnt}
+                  isLogin={isLogin}
+                  setIsModal={setIsModal}
+                />
+              ))}
+          </ResultItemBox>
+        </ResultBox>
+      </ResultContainer>
     </PageLayout>
   );
 };
+
+const ResultContainer = tw.div`
+mt-[500px] mb-[60px] h-full
+`;
+const ResultBox = tw.div`
+h-full rounded-t-[15px] py-2 pb-5
+`;
+const Bar = tw.div`
+m-auto flex h-1 w-[60px] justify-center rounded-sm bg-line-normal
+`;
+const ResultItemBox = tw.div`
+grid w-full grid-cols-2 content-center items-center gap-2 pt-4 px-4
+`;
 
 export default Location;


### PR DESCRIPTION
## 🛠 작업 내용

close #92 

- 내 주변 페이지 구현완료했습니다.
- 기존 카테고리에서 브랜드 선택시 브랜드 교체마다 api 재요청을 통해 지점 값을 교체하여 렌더링했는데, 추가적인 api 재요청없이 필터링통해서 렌더링하도록 수정했습니다.
- 외부이미지 받아오기 위해 next.config.js 파일에 도메인을 추가했습니다.

## 📸 스크린샷 or GIF


