### PR TITLE
refactor: #124/ 키워드 검색 후 지도 버튼 클릭시 마커 중심 이동

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -7,3 +7,10 @@ type Position = {
   lat: number;
   lng: number;
 };
+
+type Bound = {
+  ha: number;
+  oa: number;
+  pa: number;
+  qa: number;
+};

--- a/src/components/common/LocationMap.tsx
+++ b/src/components/common/LocationMap.tsx
@@ -11,16 +11,16 @@ type MapProps = {
   shopInfo: ShopProps[] | undefined;
   kakaoMap: any;
   setKakaoMap: Dispatch<SetStateAction<any>>;
-  setLocation: Dispatch<SetStateAction<Position>>;
   setCurPos: SetterOrUpdater<Position>;
+  setBounds: SetterOrUpdater<Bound>;
 };
 
 const LocationMap = ({
   shopInfo,
   kakaoMap,
   setKakaoMap,
-  setLocation,
   setCurPos,
+  setBounds,
 }: MapProps) => {
   const mapContainer = useRef<HTMLDivElement>(null);
   const [markers, setMarkers] = useState<any[]>([]);
@@ -38,10 +38,9 @@ const LocationMap = ({
       window.kakao.maps.load(() => {
         const mapOption = {
           center: new kakao.maps.LatLng(33.450701, 126.570667),
-          level: 3,
+          level: 5,
         };
         const map = new kakao.maps.Map(mapContainer.current, mapOption);
-        setLocation({ lat: 33.450701, lng: 126.570667 });
         setCurPos((location) => {
           return { ...location, lat: 33.450701, lng: 126.570667 };
         });
@@ -49,7 +48,6 @@ const LocationMap = ({
         if (navigator.geolocation) {
           navigator.geolocation.getCurrentPosition(({ coords }) => {
             const { latitude, longitude } = coords;
-            setLocation({ lat: latitude, lng: longitude });
             setCurPos((location) => {
               return { ...location, lat: latitude, lng: longitude };
             });
@@ -85,6 +83,7 @@ const LocationMap = ({
       const imageOption = {
         offset: new kakao.maps.Point(20, 30),
       };
+      const bounds = new kakao.maps.LatLngBounds();
       setMarkers(() => {
         return shopInfo.map((shop) => {
           const position = new kakao.maps.LatLng(
@@ -103,8 +102,12 @@ const LocationMap = ({
             image: normalImage,
             clickable: true,
           });
+          bounds.extend(position);
           return marker;
         });
+      });
+      setBounds(() => {
+        return bounds;
       });
     }
   }, [shopInfo, kakaoMap]);
@@ -112,7 +115,7 @@ const LocationMap = ({
   return (
     <>
       <div
-        className="fixed top-0 z-0 h-full w-full max-w-[375px]"
+        className="fixed top-0 z-0 h-[500px] w-full max-w-[375px]"
         ref={mapContainer}
       ></div>
     </>

--- a/src/components/common/Map.tsx
+++ b/src/components/common/Map.tsx
@@ -15,6 +15,7 @@ type MapProps = {
   setLocation: Dispatch<SetStateAction<Position>>;
   setMapPos: Dispatch<SetStateAction<Position>>;
   setCurPos: SetterOrUpdater<Position>;
+  setBounds: SetterOrUpdater<any>;
 };
 
 const Map = ({
@@ -25,6 +26,7 @@ const Map = ({
   setLocation,
   setMapPos,
   setCurPos,
+  setBounds,
 }: MapProps) => {
   const mapContainer = useRef<HTMLDivElement>(null);
   const [markers, setMarkers] = useState<any[]>([]);
@@ -93,6 +95,7 @@ const Map = ({
       const imageOption = {
         offset: new kakao.maps.Point(20, 30),
       };
+      const bounds = new kakao.maps.LatLngBounds();
       let selectedMarker = null as any;
       setMarkers(() => {
         return shopInfo.map((shop) => {
@@ -118,6 +121,7 @@ const Map = ({
             image: normalImage,
             clickable: true,
           });
+          bounds.extend(position);
           new kakao.maps.event.addListener(marker, 'click', () => {
             setModalProps(shop);
             kakaoMap.panTo(position);
@@ -131,6 +135,9 @@ const Map = ({
           });
           return marker;
         });
+      });
+      setBounds(() => {
+        return bounds;
       });
     }
   }, [shopInfo, kakaoMap]);

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -1,9 +1,11 @@
-import Image from 'next/image';
-import { useRouter } from 'next/router';
-import { useState, SetStateAction, Dispatch } from 'react';
 import tw from 'tailwind-styled-components';
+import Image from 'next/image';
 import FavoriteButton from '@components/wish/FavoriteButton';
 import Search from '@components/navbar/Search';
+import { useRouter } from 'next/router';
+import { useState, SetStateAction, Dispatch, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import { boundState } from '@recoil/boundState';
 
 type NavBarProps = {
   leftTitle?: string;
@@ -14,6 +16,7 @@ type NavBarProps = {
   shopId?: number;
   isFavorite?: boolean;
   location?: Position;
+  kakaoMap?: any;
   setShopsInfo?: Dispatch<SetStateAction<ShopProps[] | undefined>>;
 };
 
@@ -26,6 +29,7 @@ const NavBar = ({
   shopId,
   isFavorite,
   location,
+  kakaoMap,
   setShopsInfo,
 }: NavBarProps) => {
   const router = useRouter();
@@ -33,12 +37,21 @@ const NavBar = ({
   const [isList, setIsList] = useState<boolean>(false);
   const [isMap, setIsMap] = useState<boolean>(false);
   const [shopInfo, setShopInfo] = useState<Shop[]>();
+  const [isBound, setIsBound] = useState<boolean>(false);
+  const bounds = useRecoilValue(boundState);
   const handleCloseInput = () => {
     setIsInput(false);
   };
   const handleOpenInput = () => {
     setIsInput(true);
   };
+
+  useEffect(() => {
+    if (kakaoMap && isBound) {
+      kakaoMap.setBounds(bounds);
+      setIsBound(() => false);
+    }
+  }, [bounds]);
 
   return (
     <NavContainer>
@@ -83,6 +96,7 @@ const NavBar = ({
                     setIsList(false);
                     setIsMap(true);
                     setShopsInfo(shopInfo);
+                    setIsBound(true);
                   }}
                 >
                   <Image

--- a/src/hooks/queries/useGetShop.ts
+++ b/src/hooks/queries/useGetShop.ts
@@ -9,6 +9,7 @@ export const useGetShopDetail = (shopId: number, lat: number, lng: number) => {
       retry: false,
       refetchOnWindowFocus: false,
       enabled: !!lat,
+      staleTime: Infinity,
     },
   );
 };

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,6 +1,3 @@
-import { useEffect, useState } from 'react';
-import { useGetShopsInRad } from '@hooks/queries/useGetShop';
-import { getToken } from '@utils/token';
 import NavBar from '@components/common/NavBar';
 import PageLayout from '@components/layout/PageLayout';
 import Category from '@components/home/Category';
@@ -9,8 +6,14 @@ import TrackerButton from '@components/home/TrackerButton';
 import ShopModal from '@components/home/ShopModal';
 import Map from '@components/common/Map';
 import Modal from '@components/common/Modal';
-import { useRecoilState } from 'recoil';
+import { useEffect, useState } from 'react';
+import { useGetShopsInRad } from '@hooks/queries/useGetShop';
+import { getToken } from '@utils/token';
+import { useRecoilState, RecoilEnv } from 'recoil';
 import { curPosState } from '@recoil/position';
+import { boundState } from '@recoil/boundState';
+
+RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
 
 const Home = () => {
   const [isLogin, setIsLogin] = useState<boolean>(false);
@@ -20,6 +23,7 @@ const Home = () => {
   const [shopsInfo, setShopsInfo] = useState<ShopProps[]>();
   const [kakaoMap, setKakaoMap] = useState<any>(null);
   const [curPos, setCurPos] = useRecoilState(curPosState);
+  const [bounds, setBounds] = useRecoilState<Bound>(boundState);
   const [location, setLocation] = useState<Position>({
     lat: 0,
     lng: 0,
@@ -37,7 +41,6 @@ const Home = () => {
     brd,
     2000,
   );
-
   useEffect(() => {
     if (getToken().accessToken) {
       setIsLogin(true);
@@ -87,6 +90,7 @@ const Home = () => {
         isRight={true}
         location={curPos}
         setShopsInfo={setShopsInfo}
+        kakaoMap={kakaoMap}
       />
       <div className="fixed z-10">
         <Category setBrd={setBrd} />
@@ -102,6 +106,7 @@ const Home = () => {
         setModalProps={setModalProps}
         setMapPos={setMapPos}
         setCurPos={setCurPos}
+        setBounds={setBounds}
       />
       <div className="fixed bottom-0 w-full max-w-[375px] pb-[71px]">
         <TrackerButton onClick={handleTracker} />

--- a/src/pages/location/index.tsx
+++ b/src/pages/location/index.tsx
@@ -1,16 +1,17 @@
 import tw from 'tailwind-styled-components';
 import NavBar from '@components/common/NavBar';
 import PageLayout from '@components/layout/PageLayout';
-import { useState, useEffect } from 'react';
-import { useGetShopsInRad } from '@hooks/queries/useGetShop';
 import LocationMap from '@components/common/LocationMap';
 import TrackerButton from '@components/home/TrackerButton';
 import ShopItem from '@components/location/ShopItem';
 import Category from '@components/home/Category';
-import { getToken } from '@utils/token';
 import Modal from '@components/common/Modal';
+import { getToken } from '@utils/token';
+import { useState, useEffect } from 'react';
+import { useGetShopsInRad } from '@hooks/queries/useGetShop';
 import { useRecoilState } from 'recoil';
 import { curPosState } from '@recoil/position';
+import { boundState } from '@recoil/boundState';
 
 const Location = () => {
   const [isLogin, setIsLogin] = useState<boolean>(false);
@@ -19,10 +20,7 @@ const Location = () => {
   const [shopsInfo, setShopsInfo] = useState<ShopProps[]>();
   const [kakaoMap, setKakaoMap] = useState<any>(null);
   const [curPos, setCurPos] = useRecoilState(curPosState);
-  const [location, setLocation] = useState<Position>({
-    lat: 0,
-    lng: 0,
-  });
+  const [bounds, setBounds] = useRecoilState<Bound>(boundState);
 
   const { data: shopInfo } = useGetShopsInRad(
     curPos.lat,
@@ -73,13 +71,14 @@ const Location = () => {
         isRight={true}
         location={curPos}
         setShopsInfo={setShopsInfo}
+        kakaoMap={kakaoMap}
       />
       <LocationMap
         shopInfo={shopsInfo}
         kakaoMap={kakaoMap}
-        setLocation={setLocation}
         setKakaoMap={setKakaoMap}
         setCurPos={setCurPos}
+        setBounds={setBounds}
       />
       <div className="fixed top-[430px] w-full max-w-[375px] pb-[71px]">
         <TrackerButton onClick={handleTracker} />
@@ -101,7 +100,7 @@ const Location = () => {
                   key={shop.id}
                   brand_name={shop.brand?.brand_name as string}
                   file_path={shop.brand?.file_path as string}
-                  position={location}
+                  position={curPos}
                   id={shop.id}
                   place_name={shop.place_name}
                   star_rating={shop.star_rating_avg}

--- a/src/recoil/boundState.ts
+++ b/src/recoil/boundState.ts
@@ -1,0 +1,16 @@
+import { atom } from 'recoil';
+
+export const boundState = atom<{
+  ha: number;
+  oa: number;
+  pa: number;
+  qa: number;
+}>({
+  key: 'boundState',
+  default: {
+    ha: 0,
+    oa: 0,
+    pa: 0,
+    qa: 0,
+  },
+});


### PR DESCRIPTION
## 🛠 작업 내용

close #124 

- 키워드 검색 후 지도 버튼 클릭시 해당 검색결과 마커가 지도 중심에 표시되도록 수정했습니다.
- 키워드 검색을 통한 해당 지점의 bound를 recoilState로 관리합니다.
-  카테고리 클릭시 지점상세 api가 반복적으로 호출되는 현상을 react-query에서 staleTIme을 설정하여 invalidate query시에만 호출되도록 수정했습니다.

## 📸 스크린샷 or GIF

https://user-images.githubusercontent.com/79186378/236166126-8ad4dd34-4091-4e65-8601-93d642189a49.mov


