### PR TITLE
refactor: #136/ 유저 로그인 상태, 모달 상태 전역 관리

### DIFF
--- a/src/components/home/ShopModal.tsx
+++ b/src/components/home/ShopModal.tsx
@@ -1,11 +1,10 @@
-import tw from 'tailwind-styled-components';
 import Image from 'next/image';
 import BrandTag from '@components/common/BrandTag';
 import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
 import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
 import { useRouter } from 'next/router';
 import { useGetShopDetail } from '@hooks/queries/useGetShop';
-import { Dispatch, SetStateAction } from 'react';
+import { SetterOrUpdater } from 'recoil';
 
 type ShopModalProps = {
   id: number;
@@ -14,7 +13,7 @@ type ShopModalProps = {
   star_rating_avg: number;
   review_cnt: number;
   isLogin: boolean;
-  setIsModal: Dispatch<SetStateAction<boolean>>;
+  setIsModal: SetterOrUpdater<boolean>;
 };
 
 const ShopModal = ({
@@ -97,9 +96,5 @@ const ShopModal = ({
     </div>
   );
 };
-
-const ModalLayout = tw.div`
-absolute top-0 left-0 w-full h-full z-[999]
-`;
 
 export default ShopModal;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import tw from 'tailwind-styled-components';
+import Modal from '@components/common/Modal';
+import { useRecoilState } from 'recoil';
+import { modalState } from '@recoil/modalAtom';
 
 type Props = {
   children: React.ReactNode;
@@ -10,7 +13,22 @@ flex justify-center w-screen h-full font-Pretendard overflow-x-hidden overflow-y
 `;
 
 const Layout = ({ children }: Props) => {
-  return <LayoutBox>{children}</LayoutBox>;
+  const [isModal, setIsModal] = useRecoilState(modalState);
+  return (
+    <LayoutBox>
+      {isModal && (
+        <Modal
+          isModal={true}
+          isKakao={true}
+          title="로그인 상태가 아니에요!"
+          message="해당 페이지는 카카오톡 로그인을 하셔야 이용가능한 페이지에요. 로그인 하시겠어요?"
+          left="아니요"
+          leftEvent={() => setIsModal(false)}
+        />
+      )}
+      {children}
+    </LayoutBox>
+  );
 };
 
 export default Layout;

--- a/src/components/location/ShopItem.tsx
+++ b/src/components/location/ShopItem.tsx
@@ -5,7 +5,7 @@ import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
 import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
 import { useRouter } from 'next/router';
 import { useGetShopDetail } from '@hooks/queries/useGetShop';
-import { Dispatch, SetStateAction } from 'react';
+import { SetterOrUpdater } from 'recoil';
 
 type ShopItemProps = {
   brand_name: string;
@@ -16,7 +16,7 @@ type ShopItemProps = {
   star_rating: number;
   review_cnt: number;
   isLogin: boolean;
-  setIsModal: Dispatch<SetStateAction<boolean>>;
+  setIsModal: SetterOrUpdater<boolean>;
 };
 
 const ShopItem = ({

--- a/src/components/wish/FavoriteButton.tsx
+++ b/src/components/wish/FavoriteButton.tsx
@@ -1,11 +1,13 @@
+import tw from 'tailwind-styled-components';
 import Image from 'next/image';
-import { useState } from 'react';
-import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
 import Modal from '@components/common/Modal';
 import ToastMessage from '@components/common/ToastMessage';
-import tw from 'tailwind-styled-components';
-import { getToken } from '@utils/token';
+import { useState } from 'react';
+import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
 import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { userState } from '@recoil/userAtom';
+import { modalState } from '@recoil/modalAtom';
 
 type FavortieButtonProps = {
   shopId: number;
@@ -16,8 +18,9 @@ const FavoriteButton = ({ shopId, isFavorite }: FavortieButtonProps) => {
   const { mutate: del, isSuccess, isError } = useDeleteFavorite('/shopDetail');
   const { mutate: add } = usePostFavorite();
 
+  const setIsLoginModal = useSetRecoilState(modalState);
+  const isLogin = useRecoilValue(userState);
   const [isModal, setIsModal] = useState<boolean>(false);
-  const [isLogin, setIsLogin] = useState<boolean>(false);
   const [toast, setToast] = useState<boolean>(false);
 
   const handleAddFavorite = (shopId: number) => {
@@ -47,15 +50,6 @@ const FavoriteButton = ({ shopId, isFavorite }: FavortieButtonProps) => {
             handleToast();
           }}
         />
-      ) : !getToken().accessToken ? (
-        <Image
-          src="/svg/wish/lined-bookmark.svg"
-          width={24}
-          height={24}
-          alt="bookmark"
-          className="z-[900] cursor-pointer"
-          onClick={() => setIsLogin(true)}
-        />
       ) : (
         <Image
           src="/svg/wish/lined-bookmark.svg"
@@ -63,7 +57,10 @@ const FavoriteButton = ({ shopId, isFavorite }: FavortieButtonProps) => {
           height={24}
           alt="bookmark"
           className="z-[900] cursor-pointer"
-          onClick={() => handleAddFavorite(shopId)}
+          onClick={() => {
+            if (!isLogin) setIsLoginModal(true);
+            else handleAddFavorite(shopId);
+          }}
         />
       )}
 
@@ -83,18 +80,6 @@ const FavoriteButton = ({ shopId, isFavorite }: FavortieButtonProps) => {
               handleDeleteFavorite(shopId);
               setIsModal(false);
             }}
-          />
-        </ModalLayout>
-      )}
-      {isLogin && (
-        <ModalLayout>
-          <Modal
-            isModal={true}
-            isKakao={true}
-            title="로그인 상태가 아니에요!"
-            message="해당 기능은 카카오톡 로그인을 하셔야 이용가능한 기능이에요. 로그인 하시겠어요?"
-            left="아니요"
-            leftEvent={() => setIsLogin(false)}
           />
         </ModalLayout>
       )}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,13 @@
 import '@styles/globals.css';
+import tw from 'tailwind-styled-components';
+import Layout from '@components/layout/Layout';
+import Modal from '@components/common/Modal';
 import type { AppProps } from 'next/app';
 import { getLocalStorage } from '@utils/localStorage';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { ReactElement, ReactNode } from 'react';
 import { Hydrate, QueryClient, QueryClientProvider } from 'react-query';
-import Layout from '@components/layout/Layout';
-import Modal from '@components/common/Modal';
 import { RecoilRoot } from 'recoil';
 
 declare global {
@@ -35,7 +36,7 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
       !getLocalStorage('@token')
     ) {
       return (
-        <Layout>
+        <LayoutBox>
           <Modal
             isModal={true}
             isKakao={true}
@@ -44,20 +45,25 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
             left="아니요"
             leftEvent={() => router.back()}
           />
-        </Layout>
+        </LayoutBox>
       );
     }
   }
-  const getLayout = Component.getLayout ?? ((page) => <Layout>{page}</Layout>);
-  return getLayout(
+  return (
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>
         <Hydrate state={pageProps.dehydratedState}>
-          <Component {...pageProps} />
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
         </Hydrate>
       </QueryClientProvider>
-    </RecoilRoot>,
+    </RecoilRoot>
   );
 }
+
+const LayoutBox = tw.div`
+flex h-full w-screen justify-center overflow-hidden font-Pretendard
+`;
 
 export { queryClient };

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -5,19 +5,20 @@ import ResearchButton from '@components/home/ResearchButton';
 import TrackerButton from '@components/home/TrackerButton';
 import ShopModal from '@components/home/ShopModal';
 import Map from '@components/common/Map';
-import Modal from '@components/common/Modal';
 import { useEffect, useState } from 'react';
 import { useGetShopsInRad } from '@hooks/queries/useGetShop';
 import { getToken } from '@utils/token';
-import { useRecoilState, RecoilEnv } from 'recoil';
+import { useRecoilState, RecoilEnv, useSetRecoilState } from 'recoil';
 import { curPosState } from '@recoil/positionAtom';
 import { boundState } from '@recoil/boundAtom';
+import { userState } from '@recoil/userAtom';
+import { modalState } from '@recoil/modalAtom';
 
 RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
 
 const Home = () => {
-  const [isLogin, setIsLogin] = useState<boolean>(false);
-  const [isModal, setIsModal] = useState<boolean>(false);
+  const setIsModal = useSetRecoilState<boolean>(modalState);
+  const [isLogin, setIsLogin] = useRecoilState<boolean>(userState);
   const [brd, setBrd] = useState<string>('');
   const [modalProps, setModalProps] = useState<ShopProps>();
   const [shopsInfo, setShopsInfo] = useState<ShopProps[]>();
@@ -41,10 +42,10 @@ const Home = () => {
     brd,
     2000,
   );
+
   useEffect(() => {
-    if (getToken().accessToken) {
-      setIsLogin(true);
-    }
+    if (getToken().accessToken) setIsLogin(true);
+    else setIsLogin(false);
   }, []);
 
   useEffect(() => {
@@ -75,16 +76,6 @@ const Home = () => {
 
   return (
     <PageLayout>
-      {isModal && (
-        <Modal
-          isModal={isModal}
-          isKakao={true}
-          title="로그인 상태가 아니에요!"
-          message="해당 기능은 카카오톡 로그인을 하셔야 이용가능한 기능이에요. 로그인 하시겠어요?"
-          left="아니요"
-          leftEvent={() => setIsModal(false)}
-        />
-      )}
       <NavBar
         leftTitle={shopInfo?.address}
         isRight={true}

--- a/src/pages/location/index.tsx
+++ b/src/pages/location/index.tsx
@@ -5,17 +5,18 @@ import LocationMap from '@components/common/LocationMap';
 import TrackerButton from '@components/home/TrackerButton';
 import ShopItem from '@components/location/ShopItem';
 import Category from '@components/home/Category';
-import Modal from '@components/common/Modal';
-import { getToken } from '@utils/token';
 import { useState, useEffect } from 'react';
 import { useGetShopsInRad } from '@hooks/queries/useGetShop';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { curPosState } from '@recoil/positionAtom';
 import { boundState } from '@recoil/boundAtom';
+import { userState } from '@recoil/userAtom';
+import { modalState } from '@recoil/modalAtom';
 
 const Location = () => {
-  const [isLogin, setIsLogin] = useState<boolean>(false);
-  const [isModal, setIsModal] = useState<boolean>(false);
+  const isLogin = useRecoilValue<boolean>(userState);
+  const setIsModal = useSetRecoilState<boolean>(modalState);
+
   const [brd, setBrd] = useState<string>('');
   const [shopsInfo, setShopsInfo] = useState<ShopProps[]>();
   const [kakaoMap, setKakaoMap] = useState<any>(null);
@@ -42,12 +43,6 @@ const Location = () => {
     }
   }, [shopInfo, brd]);
 
-  useEffect(() => {
-    if (getToken().accessToken) {
-      setIsLogin(true);
-    }
-  }, []);
-
   const handleTracker = () => {
     const { kakao } = window;
     const moveLatLng = new kakao.maps.LatLng(curPos.lat, curPos.lng);
@@ -56,16 +51,6 @@ const Location = () => {
   };
   return (
     <PageLayout className="bg-white">
-      {isModal && (
-        <Modal
-          isModal={isModal}
-          isKakao={true}
-          title="로그인 상태가 아니에요!"
-          message="해당 기능은 카카오톡 로그인을 하셔야 이용가능한 기능이에요. 로그인 하시겠어요?"
-          left="아니요"
-          leftEvent={() => setIsModal(false)}
-        />
-      )}
       <NavBar
         leftTitle={shopInfo?.address}
         isRight={true}

--- a/src/pages/shopDetail/index.tsx
+++ b/src/pages/shopDetail/index.tsx
@@ -1,10 +1,4 @@
 import Image from 'next/image';
-import { useRef, useState } from 'react';
-import { QueryClient, dehydrate } from 'react-query';
-import { GetServerSideProps } from 'next';
-import { useRouter } from 'next/router';
-import { useGetShopDetail } from '@hooks/queries/useGetShop';
-import { useGetAllShopReviews } from '@hooks/queries/useGetReview';
 import shopApi from '@apis/shop/shopApi';
 import NavBar from '@components/common/NavBar';
 import ShopLayout from '@components/layout/ShopLayout';
@@ -14,14 +8,24 @@ import tw from 'tailwind-styled-components';
 import Button from '@components/common/Button';
 import BrandTag from '@components/common/BrandTag';
 import Scripts from '@components/common/Scripts';
+import { useRef, useState } from 'react';
+import { QueryClient, dehydrate } from 'react-query';
+import { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
+import { useGetShopDetail } from '@hooks/queries/useGetShop';
+import { useGetAllShopReviews } from '@hooks/queries/useGetReview';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { userState } from '@recoil/userAtom';
+import { modalState } from '@recoil/modalAtom';
 
 const ShopDetail = ({ shopId, userLat, userLng }) => {
   const router = useRouter();
   const mapContainer = useRef<HTMLDivElement>(null);
 
+  const isLogin = useRecoilValue(userState);
+  const setIsModal = useSetRecoilState(modalState);
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [reviewLoaded, setReviewLoaded] = useState<boolean>(false);
-
   const { data: shopInfo } = useGetShopDetail(shopId, userLat, userLng);
   const { data: additionalReview } = useGetAllShopReviews(shopId);
 
@@ -56,7 +60,6 @@ const ShopDetail = ({ shopId, userLat, userLng }) => {
     }
   };
 
-  console.log(shopInfo);
   return (
     <ShopLayout className="bg-white pt-[62px]">
       {shopInfo && (
@@ -165,9 +168,10 @@ const ShopDetail = ({ shopId, userLat, userLng }) => {
         )}
       </ShopInfoBox>
       <Button
-        handleButton={() =>
-          router.push(`/shopDetail/review?shopId=${shopInfo?.id}`)
-        }
+        handleButton={() => {
+          if (!isLogin) setIsModal(() => true);
+          else router.push(`/shopDetail/review?shopId=${shopInfo?.id}`);
+        }}
       />
     </ShopLayout>
   );

--- a/src/recoil/modalAtom.ts
+++ b/src/recoil/modalAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const modalState = atom<boolean>({
+  key: 'modalState',
+  default: false,
+});

--- a/src/recoil/userAtom.ts
+++ b/src/recoil/userAtom.ts
@@ -1,0 +1,24 @@
+import { atom } from 'recoil';
+
+const localStorageEffect =
+  (key: string) =>
+  ({ setSelf, onSet }: any) => {
+    const savedValue =
+      typeof window !== 'undefined' ? localStorage.getItem(key) : null;
+
+    if (savedValue != null) {
+      setSelf(JSON.parse(savedValue));
+    }
+
+    onSet((newValue: any, _: any, isReset: boolean) => {
+      isReset
+        ? localStorage.removeItem(key)
+        : localStorage.setItem(key, JSON.stringify(newValue));
+    });
+  };
+
+export const userState = atom<boolean>({
+  key: 'userState',
+  default: false,
+  effects: [localStorageEffect('isLogin')],
+});

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -25,4 +25,5 @@ export const setToken = (token: Token) => {
 
 export const deleteToken = () => {
   removeLocalStorage(TOKEN_KEY);
+  removeLocalStorage('isLogin');
 };


### PR DESCRIPTION
## 🛠 작업 내용

close #136 

- 유저 로그인 상태와 모달 상태를 recoil로 전역으로 관리하도록 수정했습니다.
- 로그인 상태가 아닐때, 로그인 모달창을 띄우는 관련 로직 또한 다수 존재하여, `Layout` 컴포넌트 내에서 일괄적으로 모달을 관리하도록 수정했습니다.
- 각 페이지에서는 recoil의 `useSetRecoilState` 훅을 통해 모달의 상태를 조작합니다.
- pagePerLayout을 사용하지 않아 `_app.tsx`에서 getLayout을 제거했습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
