### PR TITLE
fix: #141/검색어 value 없을 때 초기 상태로 설정

### DIFF
--- a/src/components/navbar/Search.tsx
+++ b/src/components/navbar/Search.tsx
@@ -76,6 +76,8 @@ const Search = ({
       setIsTyping(true);
     } else {
       setIsTyping(false);
+      setIsList(false);
+      setIsMap(false);
     }
   }, [value]);
 
@@ -123,7 +125,7 @@ const Search = ({
           ))}
         </SearchContainer>
       )}
-      {isList && !isMap && (
+      {isList && !isMap && value && (
         <SearchContainer>
           {shops &&
             shops.map((list, idx) => (

--- a/src/components/navbar/TextHighlighted.tsx
+++ b/src/components/navbar/TextHighlighted.tsx
@@ -12,8 +12,8 @@ const TextHighlighted = ({ value, initial, rest }: HighlightedProps) => {
         space[0] === '' ? (
           <>
             <span className="text-black text-label1">{initial}</span>
-            <span className="text-label1 text-status-error">{value}</span>
-            <span className="-ml-1 text-black text-label1 ">&nbsp;{rest}</span>
+            <span className="text-label1 text-status-error">&nbsp;{value}</span>
+            <span className="-ml-1 text-black text-label1">&nbsp;{rest}</span>
           </>
         ) : (
           <>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,9 +4,7 @@ import Layout from '@components/layout/Layout';
 import Modal from '@components/common/Modal';
 import type { AppProps } from 'next/app';
 import { getLocalStorage } from '@utils/localStorage';
-import { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import { ReactElement, ReactNode } from 'react';
 import { Hydrate, QueryClient, QueryClientProvider } from 'react-query';
 import { RecoilRoot } from 'recoil';
 
@@ -17,17 +15,9 @@ declare global {
   }
 }
 
-export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
-  getLayout?: (page: ReactElement) => ReactNode;
-};
-
-type AppPropsWithLayout = AppProps & {
-  Component: NextPageWithLayout;
-};
-
 const queryClient = new QueryClient();
 
-export default function App({ Component, pageProps }: AppPropsWithLayout) {
+export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const loginRequiredPages = ['/my', '/wish'];
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
## 🛠 작업 내용
검색어 value 없을 때 초기 상태로 설정
- resolve #141

### 추가 사항
- 검색어 하이라이팅 공백 문제가 추가적으로 발생함을 발견해서 해결했습니다. 

`useGetShopsByKeword` 커스텀 훅 내부에 useEffect 사용하지 않아도 지속적인 호출은 없어보이네요. 좋지 않은 방법이여도 임시적으로 제어하기 위해 강제적으로 사용했었는데 다행이네요👍
<!--수정/추가한 작업 내용을 설명해주세요.-->

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
