### PR TITLE
refactor: #144/ review 관련 사항 수정

### DIFF
--- a/src/hooks/mutations/useDeleteReview.ts
+++ b/src/hooks/mutations/useDeleteReview.ts
@@ -11,6 +11,9 @@ export const useDeleteReview = () => {
         queryClient.invalidateQueries({
           queryKey: ['useGetAllUserReviews'],
         });
+        queryClient.invalidateQueries({
+          queryKey: ['useGetShopDetail'],
+        });
       },
     },
   );

--- a/src/hooks/mutations/usePostReview.ts
+++ b/src/hooks/mutations/usePostReview.ts
@@ -1,4 +1,5 @@
 import reviewApi from '@apis/review/reviewApi';
+import { queryClient } from 'pages/_app';
 import { useMutation } from 'react-query';
 import { useRouter } from 'next/router';
 
@@ -11,6 +12,9 @@ const usePostReview = () => {
     (formData: any) => reviewApi.postReview(formData[0], formData[1]),
     {
       onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: ['useGetShopDetail'],
+        });
         router.back();
       },
     },

--- a/src/pages/my/reviews/edit.tsx
+++ b/src/pages/my/reviews/edit.tsx
@@ -155,8 +155,9 @@ const Edit = () => {
       <Button
         text="작성 취소하기"
         isRightButton={true}
+        disabled={!watchContent}
         handleButton={() => {
-          router.push('/my/reviews');
+          router.replace('/my/reviews');
         }}
         handleRightButton={handleSubmit(onSubmit)}
       />

--- a/src/pages/my/reviews/index.tsx
+++ b/src/pages/my/reviews/index.tsx
@@ -17,7 +17,7 @@ const Reviews = () => {
   const { data: reviews } = useGetAllUserReviews();
   const { mutate: deleteReview } = useDeleteReview();
   return (
-    <PageLayout className="bg-white">
+    <PageLayout className="bg-bg-primary">
       {isModal && (
         <ModalLayout>
           <Modal
@@ -35,52 +35,67 @@ const Reviews = () => {
         </ModalLayout>
       )}
       <NavBar centerTitle="내 후기" isLeft={true} />
-      <ul className="my-[52px]">
-        {reviews?.map(({ review_info, shop_info }, idx) => (
-          <ContentBox key={idx}>
-            <div className="flex justify-between">
-              <div className="flex flex-col">
-                <span className="text-caption1">
-                  <BrandTag name={shop_info?.brand} />
-                </span>
-                <div className="mb-4 text-title1 font-semibold">
-                  {shop_info.place_name}
+      {reviews && reviews.length ? (
+        <ul className="my-[52px]">
+          {reviews?.map(({ review_info, shop_info }, idx) => (
+            <ContentBox key={idx}>
+              <div className="flex justify-between">
+                <div className="flex flex-col">
+                  <span className="text-caption1">
+                    <BrandTag name={shop_info?.brand} />
+                  </span>
+                  <div className="mb-4 text-title1 font-semibold">
+                    {shop_info.place_name}
+                  </div>
                 </div>
+                <BtnContainer>
+                  <BtnBox
+                    onClick={() =>
+                      router.replace(
+                        `/my/reviews/edit?reviewId=${review_info.id}`,
+                      )
+                    }
+                  >
+                    <Image
+                      src={'/svg/pen.svg'}
+                      width={18}
+                      height={16}
+                      alt="펜"
+                    />
+                  </BtnBox>
+                  <BtnBox
+                    onClick={() => {
+                      setReviewId(review_info.id);
+                      setIsModal(true);
+                    }}
+                  >
+                    <Image
+                      src={'/svg/trash_can.svg'}
+                      width={18}
+                      height={16}
+                      alt="쓰레기통"
+                    />
+                  </BtnBox>
+                </BtnContainer>
               </div>
-              <BtnContainer>
-                <BtnBox
-                  onClick={() =>
-                    router.push(`/my/reviews/edit?reviewId=${review_info.id}`)
-                  }
-                >
-                  <Image src={'/svg/pen.svg'} width={18} height={16} alt="펜" />
-                </BtnBox>
-                <BtnBox
-                  onClick={() => {
-                    setReviewId(review_info.id);
-                    setIsModal(true);
-                  }}
-                >
-                  <Image
-                    src={'/svg/trash_can.svg'}
-                    width={18}
-                    height={16}
-                    alt="쓰레기통"
-                  />
-                </BtnBox>
-              </BtnContainer>
-            </div>
-            <ReviewItem
-              create_date={review_info.create_date}
-              star_rating={review_info.star_rating}
-              content={review_info.content}
-              purity={review_info.purity}
-              retouch={review_info.retouch}
-              item={review_info.item}
-            />
-          </ContentBox>
-        ))}
-      </ul>
+              <ReviewItem
+                create_date={review_info.create_date}
+                star_rating={review_info.star_rating}
+                content={review_info.content}
+                purity={review_info.purity}
+                retouch={review_info.retouch}
+                item={review_info.item}
+              />
+            </ContentBox>
+          ))}
+        </ul>
+      ) : (
+        <div className="flex h-[100vh] items-center justify-center">
+          <span className="text-title2 text-text-alternative">
+            작성한 리뷰가 없습니다.
+          </span>
+        </div>
+      )}
     </PageLayout>
   );
 };

--- a/src/pages/wish/index.tsx
+++ b/src/pages/wish/index.tsx
@@ -19,7 +19,7 @@ const Wish = () => {
           ))}
         </WishList>
       ) : (
-        <div className="flex h-[70vh] items-center justify-center">
+        <div className="flex h-[100vh] items-center justify-center">
           <span className="text-title2 text-text-alternative">
             저장한 포토부스가 없습니다.
           </span>


### PR DESCRIPTION
## 🛠 작업 내용

close #144 

- 리뷰 수정 작업 시 콘텐츠가 없는 경우 버튼이 비활성화 되도록 수정했습니다.
- 리뷰 등록, 삭제 시 관련 쿼리를 무효화하도록 수정했습니다.
- 찜목록, 리뷰 작성 목록이 없을 때 보여주는 뷰의 높이를 수정했습니다.
- 리뷰 수정 페이지에 접근 후 해당 NavBar의 뒤로가기 버튼을 누르면 다시 리뷰 수정 페이지로 이동하는 문제가 있어, 리뷰 수정 페이지로 이동시  router.push가 아닌 router.replace로 처리하여 히스토리 스택에 리뷰 수정 페이지를 추가하지 않도록 수정했습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
