### PR TITLE
refactor: #152/로그인 성공 후 히스토리 스택 안 쌓이게 수정

### DIFF
--- a/src/pages/auth/kakao.tsx
+++ b/src/pages/auth/kakao.tsx
@@ -24,9 +24,9 @@ const Kakao = () => {
       };
       if (token) {
         setToken(token);
-        router.push('/home');
+        router.replace('/home');
       } else {
-        router.push('/auth/login');
+        router.replace('/auth/login');
       }
     }
     if (isLogin) {


### PR DESCRIPTION
## 🛠 작업 내용
로그인 성공 후 라우터 히스토리 스택 안 쌓이게 수정
- close #152 

## PR 세부 내용
- 이제 로그인 성공 후 뒤로가기를 해도 로그인 페이지로 이동하지 않습니다.
- 로그인 없이 이용하기 및 로그인 모달은 replace로 변경하지 않고 유지했습니다.
<!--수정/추가한 작업 내용을 설명해주세요.-->

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
