### PR TITLE
fix : #160/ 배포서버와 개발서버 redirect-uri 구분

### DIFF
--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -14,9 +14,14 @@ const Login = () => {
   const [loading, setLoading] = useState<boolean>(true);
 
   const leftEvent = () => {
-    router.push(
-      `https://kauth.kakao.com/oauth/authorize?client_id=${CONFIG.API_KEYS.LOGIN}&redirect_uri=${CONFIG.LOCAL}/auth/kakao&response_type=code`,
-    );
+    if (CONFIG.ENV === 'development') {
+      router.push(
+        `https://kauth.kakao.com/oauth/authorize?client_id=${CONFIG.API_KEYS.LOGIN}&redirect_uri=${CONFIG.LOCAL}/auth/kakao&response_type=code`,
+      );
+    } else
+      router.push(
+        `https://kauth.kakao.com/oauth/authorize?client_id=${CONFIG.API_KEYS.LOGIN}&redirect_uri=${CONFIG.DOMAIN}/auth/kakao&response_type=code`,
+      );
   };
 
   const rightEvent = () => {


### PR DESCRIPTION
## 🛠 작업 내용

close #160 

- 로그인 없이 이용 모달에서 로그인하기 버튼 클릭시 이동하는 redirect uri를 개발서버와 배포서버로 구분했습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
