### PR TITLE
refactor: #155/ 지점 상세 페이지 리팩토링 & 리뷰로 명칭 통일

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -7,18 +7,20 @@ type ButtonProps = {
   disabled?: boolean;
   handleButton?: () => void;
   handleRightButton?: () => void;
+  className?: React.ComponentProps<'div'>['className'];
 };
 
 const Button = ({
-  text = '이용후기 작성하기',
+  text = '이용리뷰 작성하기',
   isRightButton,
   rightText = '작성 완료하기',
   disabled,
   handleButton,
   handleRightButton,
+  ...rest
 }: ButtonProps) => {
   return (
-    <ButtonLayout>
+    <ButtonLayout {...rest}>
       {isRightButton ? (
         <>
           <LeftButton className="bg-fill-strong" onClick={handleButton}>

--- a/src/hooks/queries/useGetReview.ts
+++ b/src/hooks/queries/useGetReview.ts
@@ -23,15 +23,3 @@ export const useGetUserReview = (reviewId: number) => {
     },
   );
 };
-
-export const useGetAllShopReviews = (shopId: number) => {
-  return useQuery<Review[], Error>(
-    ['useGetAllShopReviews'],
-    () => reviewApi.getAllShopReviews(shopId),
-    {
-      retry: false,
-      refetchOnWindowFocus: false,
-      enabled: !!shopId,
-    },
-  );
-};

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -18,7 +18,7 @@ type SettingItemsProps = SettingListsProps & {
 };
 
 const SettingItems: SettingItemsProps[] = [
-  { id: 1, text: '내 후기', icon: '/svg/review.svg', path: '/my/reviews' },
+  { id: 1, text: '내 리뷰', icon: '/svg/review.svg', path: '/my/reviews' },
   { id: 2, text: '내 칭호', icon: '/svg/title.svg', path: '/my/titles' },
   { id: 3, text: '공지사항', icon: '/svg/notice.svg', path: '/notice' },
 ];

--- a/src/pages/my/reviews/edit.tsx
+++ b/src/pages/my/reviews/edit.tsx
@@ -67,7 +67,7 @@ const Edit = () => {
   return (
     <ShopLayout className="bg-white">
       <RatingContainer>
-        <span className="pb-6 text-title2 font-semibold">이용 후기 작성</span>
+        <span className="pb-6 text-title2 font-semibold">이용 리뷰 작성</span>
         <div className="flex text-label2">
           <span className="text-status-error">*</span>
           <span className="pb-4 pl-2 text-text-alternative">
@@ -142,7 +142,7 @@ const Edit = () => {
           />
         </OptionBox>
         <Textarea
-          label="이용후기"
+          label="이용리뷰"
           placeholder="리뷰를 남겨주세요! (100자 이내)"
           register={register('content')}
           className={

--- a/src/pages/my/reviews/index.tsx
+++ b/src/pages/my/reviews/index.tsx
@@ -34,7 +34,7 @@ const Reviews = () => {
           />
         </ModalLayout>
       )}
-      <NavBar centerTitle="내 후기" isLeft={true} />
+      <NavBar centerTitle="내 리뷰" isLeft={true} />
       {reviews && reviews.length ? (
         <ul className="my-[52px]">
           {reviews?.map(({ review_info, shop_info }, idx) => (

--- a/src/pages/my/setting.tsx
+++ b/src/pages/my/setting.tsx
@@ -43,7 +43,7 @@ const Setting = () => {
         isModal={isWithdrawModal}
         title="회원탈퇴"
         message={
-          '회원탈퇴 이후에 저장한 포토부스와 작성한 후기를\n더이상 볼 수 없어요.\n정말 탈퇴하시겠어요?'
+          '회원탈퇴 이후에 저장한 포토부스와 작성한 리뷰를\n더이상 볼 수 없어요.\n정말 탈퇴하시겠어요?'
         }
         left="취소"
         right="확인"

--- a/src/pages/shopDetail/index.tsx
+++ b/src/pages/shopDetail/index.tsx
@@ -7,11 +7,12 @@ import tw from 'tailwind-styled-components';
 import Button from '@components/common/Button';
 import BrandTag from '@components/common/BrandTag';
 import Scripts from '@components/common/Scripts';
+import Menu from '@components/common/Menu';
+import reviewApi from '@apis/review/reviewApi';
 import { curPosState } from '@recoil/positionAtom';
 import { useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useGetShopDetail } from '@hooks/queries/useGetShop';
-import { useGetAllShopReviews } from '@hooks/queries/useGetReview';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { userState } from '@recoil/userAtom';
 import { modalState } from '@recoil/modalAtom';
@@ -28,9 +29,9 @@ const ShopDetail = () => {
 
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [reviewLoaded, setReviewLoaded] = useState<boolean>(false);
+  const [reviews, setReviews] = useState<Review[]>([]);
 
   const { data: shopInfo } = useGetShopDetail(shopId, curPos.lat, curPos.lng);
-  const { data: additionalReview } = useGetAllShopReviews(shopId);
 
   const handleShareButton = (
     place_name: string,
@@ -84,7 +85,7 @@ const ShopDetail = () => {
         <ShopName>{shopInfo?.place_name}</ShopName>
         <ShopRate>
           <div className="flex items-center">
-            {shopInfo && <StarRate rate={shopInfo?.star_rating_avg} />}
+            {shopInfo && <StarRate rate={shopInfo.star_rating_avg} />}
             <div className="pl-1 pr-2">
               {shopInfo?.star_rating_avg} ({shopInfo?.review_cnt})
             </div>
@@ -130,34 +131,40 @@ const ShopDetail = () => {
             <StarRate color={true} rate={shopInfo.star_rating_avg} />
           )}
         </ReviewInfoBox>
-        {!reviewLoaded
-          ? shopInfo?.recent_reviews.map(({ review_info, member_info }) => (
-              <ReviewItem
-                key={review_info.id}
-                create_date={review_info.create_date}
-                star_rating={review_info.star_rating}
-                content={review_info.content}
-                purity={review_info.purity}
-                retouch={review_info.retouch}
-                item={review_info.item}
-                member_info={member_info as member_info}
-              />
-            ))
-          : additionalReview?.map(({ review_info, member_info }) => (
-              <ReviewItem
-                key={review_info.id}
-                create_date={review_info.create_date}
-                star_rating={review_info.star_rating}
-                content={review_info.content}
-                purity={review_info.purity}
-                retouch={review_info.retouch}
-                item={review_info.item}
-                member_info={member_info as member_info}
-              />
-            ))}
+        {shopInfo?.recent_reviews.length === 0 ? (
+          <span>작성된 리뷰가 없습니다.</span>
+        ) : reviewLoaded && reviews ? (
+          reviews.map(({ review_info, member_info }) => (
+            <ReviewItem
+              key={review_info.id}
+              create_date={review_info.create_date}
+              star_rating={review_info.star_rating}
+              content={review_info.content}
+              purity={review_info.purity}
+              retouch={review_info.retouch}
+              item={review_info.item}
+              member_info={member_info as member_info}
+            />
+          ))
+        ) : (
+          shopInfo?.recent_reviews.map(({ review_info, member_info }) => (
+            <ReviewItem
+              key={review_info.id}
+              create_date={review_info.create_date}
+              star_rating={review_info.star_rating}
+              content={review_info.content}
+              purity={review_info.purity}
+              retouch={review_info.retouch}
+              item={review_info.item}
+              member_info={member_info as member_info}
+            />
+          ))
+        )}
         {!reviewLoaded && (shopInfo?.review_cnt as number) > 3 && (
           <LoadReviewBtn
-            onClick={() => {
+            onClick={async () => {
+              const res = await reviewApi.getAllShopReviews(shopId);
+              setReviews(res);
               setReviewLoaded(true);
             }}
           >
@@ -167,11 +174,13 @@ const ShopDetail = () => {
         )}
       </ShopInfoBox>
       <Button
+        className="bottom-[72px]"
         handleButton={() => {
           if (!isLogin) setIsModal(() => true);
           else router.push(`/shopDetail/review?shopId=${shopInfo?.id}`);
         }}
       />
+      <Menu />
     </ShopLayout>
   );
 };
@@ -180,7 +189,7 @@ const Map = tw.div`
 h-[270px] w-full pt-[62px]
 `;
 const ShopInfoBox = tw.div`
-flex flex-col px-4 pt-4 pb-2 mb-[52px]
+flex flex-col px-4 pt-4 pb-2 mb-[122px]
 `;
 const ShopTagBox = tw.div`
 mb-2 text-caption2

--- a/src/pages/shopDetail/review.tsx
+++ b/src/pages/shopDetail/review.tsx
@@ -53,7 +53,7 @@ const Review = () => {
   return (
     <ShopLayout className="bg-white">
       <RatingContainer>
-        <span className="pb-6 text-title2 font-semibold">이용 후기 작성</span>
+        <span className="pb-6 text-title2 font-semibold">이용 리뷰 작성</span>
         <div className="flex text-label2">
           <span className="text-status-error">*</span>
           <span className="pb-4 pl-2 text-text-alternative">
@@ -107,7 +107,7 @@ const Review = () => {
           />
         </OptionBox>
         <Textarea
-          label="이용후기"
+          label="이용리뷰"
           placeholder="리뷰를 남겨주세요! (100자 이내)"
           register={register('content')}
           className={


### PR DESCRIPTION
## 🛠 작업 내용

close #155
close #154 

- 지점 상세 페이지에 메뉴 컴포넌트를 추가했습니다.
- 지점 상세페이지에 접근시 지점 모든 리뷰를 가져오도록 되어있었는데, 추가 리뷰 버튼을 누르면 모든 리뷰를 가져오게하여 불필요한 api 호출을 수정했습니다.
- 후기 -> 리뷰로 명칭을 통일했습니다.

## 📸 스크린샷 or GIF

![스크린샷 2023-05-17 오후 5 43 02](https://github.com/4-frame-photos-map/frontend/assets/79186378/64962e72-3e70-4434-8b26-3aae95d44c76)
