### PR TITLE
fix: #170/#173/ 검색 후 기존 모달 유지 & 검색 결과 필터링

### DIFF
--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -17,8 +17,10 @@ type NavBarProps = {
   isFavorite?: boolean;
   location?: Position;
   kakaoMap?: any;
-  setShopsInfo?: Dispatch<SetStateAction<ShopProps[] | undefined>>;
   favoritesNum?: number;
+  setShopsInfo?: Dispatch<SetStateAction<ShopProps[] | undefined>>;
+  setCurShopsInfo?: Dispatch<SetStateAction<ShopProps[] | undefined>>;
+  setModalProps?: Dispatch<SetStateAction<ShopProps | undefined>>;
 };
 
 const NavBar = ({
@@ -31,8 +33,10 @@ const NavBar = ({
   isFavorite,
   location,
   kakaoMap,
-  setShopsInfo,
   favoritesNum,
+  setShopsInfo,
+  setCurShopsInfo,
+  setModalProps,
 }: NavBarProps) => {
   const router = useRouter();
   const [isInput, setIsInput] = useState<boolean>(false);
@@ -73,7 +77,7 @@ const NavBar = ({
             {isMap && (
               <>
                 <div
-                  className="flex flex-col items-center ml-1"
+                  className="ml-1 flex flex-col items-center"
                   onClick={() => {
                     setIsMap(false);
                     setIsList(true);
@@ -93,11 +97,13 @@ const NavBar = ({
             {isList && setShopsInfo && (
               <>
                 <div
-                  className="flex flex-col items-center ml-1"
+                  className="ml-1 flex flex-col items-center"
                   onClick={() => {
                     setIsList(false);
                     setIsMap(true);
                     setShopsInfo(shopInfo);
+                    setCurShopsInfo?.(shopInfo);
+                    setModalProps?.(undefined);
                     setIsBound(true);
                   }}
                 >
@@ -139,10 +145,7 @@ const NavBar = ({
             />
           </>
         )}
-        {leftTitle &&
-        !isInput &&
-        location?.lat !== 33.450701 &&
-        location?.lng !== 126.570667 ? (
+        {leftTitle && !isInput ? (
           <LeftTitle>{leftTitle}</LeftTitle>
         ) : (
           <div></div>
@@ -158,7 +161,7 @@ const NavBar = ({
                 height={16}
                 className="right-0 z-[999]"
               />
-              <span className="font-semibold text-caption1">검색</span>
+              <span className="text-caption1 font-semibold">검색</span>
             </Border>
           )
         ) : null}
@@ -167,7 +170,7 @@ const NavBar = ({
         )}
         {favoritesNum && (
           <Border>
-            <span className="font-semibold text-caption1">
+            <span className="text-caption1 font-semibold">
               총 {favoritesNum}개
             </span>
           </Border>

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -59,7 +59,6 @@ const Home = () => {
       const brdShops = curShopsInfo?.filter(
         (shop) => shop.brand?.brand_name === brd,
       );
-      console.log(brdShops);
       setShopsInfo(brdShops);
     } else {
       setShopsInfo(curShopsInfo);

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -22,6 +22,7 @@ const Home = () => {
   const [brd, setBrd] = useState<string>('');
   const [modalProps, setModalProps] = useState<ShopProps>();
   const [shopsInfo, setShopsInfo] = useState<ShopProps[]>();
+  const [curShopsInfo, setCurShopsInfo] = useState<ShopProps[]>();
   const [kakaoMap, setKakaoMap] = useState<any>(null);
   const [curPos, setCurPos] = useRecoilState(curPosState);
   const [bounds, setBounds] = useRecoilState<Bound>(boundState);
@@ -49,15 +50,21 @@ const Home = () => {
   }, []);
 
   useEffect(() => {
+    setShopsInfo(shopInfo?.shops);
+    setCurShopsInfo(shopInfo?.shops);
+  }, [shopInfo]);
+
+  useEffect(() => {
     if (brd) {
-      const brdShops = shopInfo?.shops.filter(
+      const brdShops = curShopsInfo?.filter(
         (shop) => shop.brand?.brand_name === brd,
       );
+      console.log(brdShops);
       setShopsInfo(brdShops);
     } else {
-      setShopsInfo(shopInfo?.shops);
+      setShopsInfo(curShopsInfo);
     }
-  }, [shopInfo, brd]);
+  }, [brd]);
 
   const handleTracker = () => {
     const { kakao } = window;
@@ -67,6 +74,8 @@ const Home = () => {
     setModalProps(undefined);
     setMapPos({ lat: location.lat, lng: location.lng });
     setLocation({ ...location, lat: curPos.lat, lng: curPos.lng });
+    setShopsInfo(shopInfo?.shops);
+    setCurShopsInfo(shopInfo?.shops);
   };
 
   const handleResearch = () => {
@@ -81,6 +90,8 @@ const Home = () => {
         isRight={true}
         location={curPos}
         setShopsInfo={setShopsInfo}
+        setModalProps={setModalProps}
+        setCurShopsInfo={setCurShopsInfo}
         kakaoMap={kakaoMap}
       />
       <div className="fixed z-10">

--- a/src/pages/location/index.tsx
+++ b/src/pages/location/index.tsx
@@ -43,7 +43,6 @@ const Location = () => {
       const brdShops = curShopsInfo?.filter(
         (shop) => shop.brand?.brand_name === brd,
       );
-      console.log(brdShops);
       setShopsInfo(brdShops);
     } else {
       setShopsInfo(curShopsInfo);

--- a/src/pages/location/index.tsx
+++ b/src/pages/location/index.tsx
@@ -18,6 +18,7 @@ const Location = () => {
   const setIsModal = useSetRecoilState<boolean>(modalState);
 
   const [brd, setBrd] = useState<string>('');
+  const [curShopsInfo, setCurShopsInfo] = useState<ShopProps[]>();
   const [shopsInfo, setShopsInfo] = useState<ShopProps[]>();
   const [kakaoMap, setKakaoMap] = useState<any>(null);
   const [curPos, setCurPos] = useRecoilState(curPosState);
@@ -33,21 +34,29 @@ const Location = () => {
   );
 
   useEffect(() => {
+    setShopsInfo(shopInfo?.shops);
+    setCurShopsInfo(shopInfo?.shops);
+  }, [shopInfo]);
+
+  useEffect(() => {
     if (brd) {
-      const brdShops = shopInfo?.shops.filter(
+      const brdShops = curShopsInfo?.filter(
         (shop) => shop.brand?.brand_name === brd,
       );
+      console.log(brdShops);
       setShopsInfo(brdShops);
     } else {
-      setShopsInfo(shopInfo?.shops);
+      setShopsInfo(curShopsInfo);
     }
-  }, [shopInfo, brd]);
+  }, [brd]);
 
   const handleTracker = () => {
     const { kakao } = window;
     const moveLatLng = new kakao.maps.LatLng(curPos.lat, curPos.lng);
     kakaoMap.setLevel(3);
     kakaoMap.panTo(moveLatLng);
+    setShopsInfo(shopInfo?.shops);
+    setCurShopsInfo(shopInfo?.shops);
   };
   return (
     <PageLayout className="bg-white">
@@ -56,6 +65,7 @@ const Location = () => {
         isRight={true}
         location={curPos}
         setShopsInfo={setShopsInfo}
+        setCurShopsInfo={setCurShopsInfo}
         kakaoMap={kakaoMap}
       />
       <LocationMap


### PR DESCRIPTION
## 🛠 작업 내용

close #170  close #173 

- 지점 모달이 화면에 있는경우 검색 시 기존 모달이 유지되는 현상을 수정했습니다.
- 검색 결과 바탕으로 필터링 시 기존 위치 지점들이 필터링되는 현상을 수정했습니다.
- 기존 NavBar에서 본사 위치일 때 위치주소가 나타나지 않게끔 했던 부분을, 본사 위치를 setState 하지 않도록 로직을 수정함에 따라 제거했습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
