### PR TITLE
feat: #179/대표칭호 컴포넌트 작성 및 적용

### DIFF
--- a/src/apis/review/review.d.ts
+++ b/src/apis/review/review.d.ts
@@ -24,6 +24,7 @@ type ReviewInfoProps = {
 type member_info = {
   id: number;
   nickname: string;
+  main_member_title: string;
 };
 
 type shop_info = {

--- a/src/apis/shop/shop.d.ts
+++ b/src/apis/shop/shop.d.ts
@@ -38,6 +38,7 @@ type ShopReviewProps = {
   member_info: {
     id: number;
     nickname: string;
+    main_member_title: string;
   };
 };
 

--- a/src/apis/title/title.d.ts
+++ b/src/apis/title/title.d.ts
@@ -3,6 +3,8 @@ type MemberTitle = {
   main_member_title: {
     id: number;
     name: string;
+    standard: string;
+    content: string;
     image_url: string;
     is_holding: boolean;
     is_main: boolean;
@@ -11,6 +13,8 @@ type MemberTitle = {
     {
       id: number;
       name: string;
+      standard: string;
+      content: string;
       image_url: string;
       is_holding: boolean;
       is_main: boolean;

--- a/src/apis/title/titleApi.ts
+++ b/src/apis/title/titleApi.ts
@@ -1,7 +1,7 @@
 import instance from '@apis/instance';
 
 class TitleApi {
-  getTitle = async (id: number): Promise<MemberTitle> => {
+  getUserTitle = async (id: number): Promise<MemberTitle> => {
     const { data } = await instance.get(`/member-titles/${id}`);
     return data;
   };

--- a/src/components/common/ReviewItem.tsx
+++ b/src/components/common/ReviewItem.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import tw from 'tailwind-styled-components';
 import StarRate from '@components/common/StarRate';
 import dateFormat from '@utils/dateFormat';
+import TitleBadge from '@components/title/TitleBadge';
 
 type ReviewItemProps = {
   create_date: number[];
@@ -10,10 +11,7 @@ type ReviewItemProps = {
   purity?: string;
   retouch?: string;
   item?: string;
-  member_info?: {
-    id: number;
-    nickname: string;
-  };
+  member_info?: member_info;
 };
 
 const ReviewItem = ({
@@ -34,6 +32,14 @@ const ReviewItem = ({
             {member_info && (
               <div className="pl-[6px]">{member_info.nickname}</div>
             )}
+            <div className="ml-2">
+              {member_info?.main_member_title && (
+                <TitleBadge
+                  className="h-[14px] w-fit px-2 text-[9px]"
+                  name={member_info.main_member_title as string}
+                />
+              )}
+            </div>
           </div>
           <div>{dateFormat(create_date)}</div>
         </ReviewInfo>

--- a/src/components/common/ReviewItem.tsx
+++ b/src/components/common/ReviewItem.tsx
@@ -35,7 +35,7 @@ const ReviewItem = ({
             <div className="ml-2">
               {member_info?.main_member_title && (
                 <TitleBadge
-                  className="h-[14px] w-fit px-2 text-[9px]"
+                  className="h-fit w-fit px-2 text-[9px]"
                   name={member_info.main_member_title as string}
                 />
               )}

--- a/src/components/home/ShopModal.tsx
+++ b/src/components/home/ShopModal.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 import { useGetShopDetail } from '@hooks/queries/useGetShop';
 import { SetterOrUpdater, useRecoilValue } from 'recoil';
 import { curPosState } from '@recoil/positionAtom';
-import ShopTitle from '@components/common/ShopTitle';
+import ShopTitle from '@components/title/ShopTitle';
 
 type ShopModalProps = {
   id: number;
@@ -49,7 +49,7 @@ const ShopModal = ({
       <div className="p-4">
         <div className="flex items-center">
           <BrandTag name={place_name} />
-          <div className="flex ml-2">
+          <div className="ml-2 flex">
             {shopInfo?.shop_titles &&
               shopInfo?.shop_titles?.map((title, idx) => (
                 <ShopTitle key={idx} title={title} width={50} height={13} />
@@ -90,7 +90,7 @@ const ShopModal = ({
               <Image src="/svg/star.svg" width={16} height={16} alt="star" />
               {star_rating_avg}({review_cnt})
             </span>
-            <div className="pl-2 border-l">
+            <div className="border-l pl-2">
               <span className="pr-1">찜</span>
               <span className="font-semibold">{shopInfo?.favorite_cnt}</span>
             </div>

--- a/src/components/location/ShopItem.tsx
+++ b/src/components/location/ShopItem.tsx
@@ -5,7 +5,7 @@ import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
 import { useRouter } from 'next/router';
 import { useGetShopDetail } from '@hooks/queries/useGetShop';
 import { SetterOrUpdater } from 'recoil';
-import ShopTitle from '@components/common/ShopTitle';
+import ShopTitle from '@components/title/ShopTitle';
 
 type ShopItemProps = {
   brand_name: string;
@@ -97,7 +97,7 @@ const ShopItem = ({
             <Image src="/svg/star.svg" width={16} height={16} alt="star" />
             {star_rating} ({review_cnt})
           </span>
-          <div className="pl-2 border-l">
+          <div className="border-l pl-2">
             <span className="pr-1">찜</span>
             <span className="font-semibold">{shopInfo?.favorite_cnt}</span>
             <span className="ml-9 text-caption1 text-text-alternative">

--- a/src/components/title/ShopTitle.tsx
+++ b/src/components/title/ShopTitle.tsx
@@ -6,12 +6,12 @@ type ShopTitleProps = {
   height: number;
 };
 
-type titleListType = {
+export type titleListType = {
   [key: string]: JSX.Element;
 };
 
 const ShopTitle = ({ title, width, height }: ShopTitleProps) => {
-  const TITLE_LIST: titleListType = {
+  const shopTitleList: titleListType = {
     핫플레이스: (
       <Image
         src={'/svg/shop-title-hot-place.svg'}
@@ -29,7 +29,7 @@ const ShopTitle = ({ title, width, height }: ShopTitleProps) => {
       />
     ),
   };
-  return <>{TITLE_LIST[title]}</>;
+  return <>{shopTitleList[title]}</>;
 };
 
 export default ShopTitle;

--- a/src/components/title/TitleBadge.tsx
+++ b/src/components/title/TitleBadge.tsx
@@ -1,0 +1,27 @@
+import Image from 'next/image';
+import tw from 'tailwind-styled-components';
+
+type TitleBadgeProps = {
+  name: string;
+  className?: React.ComponentProps<'div'>['className'];
+};
+
+const TitleBadge = ({ name, ...rest }: TitleBadgeProps) => {
+  return (
+    <TitleBadgeBox {...rest} name={name}>
+      <span>{name}</span>
+    </TitleBadgeBox>
+  );
+};
+
+const TitleBadgeBox = tw.div<TitleBadgeProps>`
+${({ name }) =>
+  (name === '뉴비' && 'bg-[#6DFF39]') ||
+  (name === '찜 첫 걸음' && 'bg-[#FFA6A6]') ||
+  (name === '찜 홀릭' && 'bg-[#FF5A5A]') ||
+  (name === '리뷰 홀릭' && 'bg-[#86A1FF]') ||
+  (name === '리뷰 첫 걸음' && 'bg-[#BDD6FF]')}
+rounded-full flex justify-center items-center border-[1px] border-primary-normal font-semibold text-primary-normal whitespace-nowrap shadow-[2px_2px_4px_0px_rgba(0,0,0,0.16)]
+`;
+
+export default TitleBadge;

--- a/src/components/title/TitleInfo.tsx
+++ b/src/components/title/TitleInfo.tsx
@@ -3,13 +3,7 @@ import Image from 'next/image';
 const TitleInfo = () => {
   return (
     <div className="absolute right-3 -top-3 mt-[80px] flex flex-col items-center">
-      <Image
-        src="/svg/union.svg"
-        width={323}
-        height={100}
-        alt="칭호 정보"
-        className="relative"
-      />
+      <Image src="/svg/union.svg" width={323} height={100} alt="칭호 정보" />
       <div className="relative -top-16 z-[999] flex flex-col items-center text-label2 font-semibold">
         <span>매일 02시에 회원 칭호가 부여됩니다.</span>
         <span>획득한 칭호 중 하나를 대표 칭호로 설정할 수 있어요.</span>

--- a/src/components/title/TitleInfo.tsx
+++ b/src/components/title/TitleInfo.tsx
@@ -4,7 +4,7 @@ const TitleInfo = () => {
   return (
     <div className="absolute right-3 -top-3 mt-[80px] flex flex-col items-center">
       <Image src="/svg/union.svg" width={323} height={100} alt="칭호 정보" />
-      <div className="relative -top-16 z-[999] flex flex-col items-center text-label2 font-semibold">
+      <div className="relative -top-16 flex flex-col items-center text-label2 font-semibold">
         <span>매일 02시에 회원 칭호가 부여됩니다.</span>
         <span>획득한 칭호 중 하나를 대표 칭호로 설정할 수 있어요.</span>
       </div>

--- a/src/components/title/TitleModal.tsx
+++ b/src/components/title/TitleModal.tsx
@@ -10,7 +10,7 @@ type TitleModalProps = {
 };
 
 const TitleModal = ({ setIsModal, title }: TitleModalProps) => {
-  const { id, image_url, name, is_holding } = title;
+  const { id, image_url, name, is_holding, content, standard } = title;
   const { mutate } = usePatchTitle(
     id as number,
     image_url as string,
@@ -24,7 +24,6 @@ const TitleModal = ({ setIsModal, title }: TitleModalProps) => {
   const handleButtonClick = (id: number) => {
     mutate(id);
   };
-
   return (
     <ModalBG>
       <ModalContainer>
@@ -33,11 +32,21 @@ const TitleModal = ({ setIsModal, title }: TitleModalProps) => {
           width={24}
           height={24}
           alt="닫기"
-          className="absolute right-5 cursor-pointer"
+          className="absolute cursor-pointer right-5"
           onClick={handleOverlayClick}
         />
         <Image src={image_url as string} width={120} height={120} alt="칭호" />
-        <span className="mt-4 text-label1 font-semibold">{name}</span>
+        <span className="mt-4 font-semibold text-label1">{name}</span>
+        {is_holding ? (
+          <span className="mt-2 text-label2">{standard}</span>
+        ) : (
+          <span className="flex mt-2 text-center text-label2">
+            획득방법:
+            <br />
+            {content}
+          </span>
+        )}
+
         {is_holding ? (
           <ActiveButton
             onClick={() => {
@@ -84,11 +93,11 @@ flex flex-col items-center bg-white rounded-lg w-full h-[338px] bottom-0 absolut
 `;
 
 const ActiveButton = tw.button`
-mt-16 flex h-12 w-[255px] items-center justify-center whitespace-nowrap rounded-full border-[1px] border-primary-normal
+mt-8 flex h-12 w-[255px] items-center justify-center whitespace-nowrap rounded-full border-[1px] border-primary-normal
 `;
 
 const DisabledButton = tw.button`
-mt-16 flex h-12 w-[255px] items-center justify-center whitespace-nowrap rounded-full border-[1px] border-text-disable text-text-disable
+mt-8 flex h-12 w-[255px] items-center justify-center whitespace-nowrap rounded-full border-[1px] border-text-disable text-text-disable
 `;
 
 export default TitleModal;

--- a/src/components/title/TitleModal.tsx
+++ b/src/components/title/TitleModal.tsx
@@ -7,7 +7,6 @@ import tw from 'tailwind-styled-components';
 type TitleModalProps = {
   setIsModal: Dispatch<SetStateAction<boolean>>;
   title: ModalTitleType;
-  disable?: boolean;
 };
 
 const TitleModal = ({ setIsModal, title }: TitleModalProps) => {

--- a/src/hooks/mutations/usePatchTitle.ts
+++ b/src/hooks/mutations/usePatchTitle.ts
@@ -18,9 +18,9 @@ export const usePatchTitle = (id: number, image_url: string, name: string) => {
               ...old,
               main_member_title: {
                 ...old.main_member_title,
-                id: id,
-                image_url: image_url,
-                name: name,
+                id,
+                image_url,
+                name,
               },
             };
           },
@@ -33,6 +33,9 @@ export const usePatchTitle = (id: number, image_url: string, name: string) => {
       onSettled: () => {
         queryClient.invalidateQueries({
           queryKey: 'useGetAllTitles',
+        });
+        queryClient.invalidateQueries({
+          queryKey: 'useGetProfile',
         });
       },
     },

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -6,6 +6,7 @@ import SettingItem from '@components/my/SettingItem';
 import SettingList from '@components/my/SettingList';
 import { useGetProfile } from '@hooks/queries/useGetProfile';
 import { useRouter } from 'next/router';
+import TitleBadge from '@components/title/TitleBadge';
 
 export type SettingListsProps = {
   id: number;
@@ -34,10 +35,11 @@ const My = () => {
   return (
     <PageLayout className="bg-white">
       <NavBar centerTitle="마이페이지" isLeft={true} />
-      <div className="mt-[77px] px-4">
-        <span className="ml-2 text-label1 text-black">
-          {user?.main_member_title}
-        </span>
+      <div className="mt-[73px] px-4">
+        <TitleBadge
+          className="px-3 h-7 w-fit text-label2"
+          name={user?.main_member_title as string}
+        />
       </div>
       <GreetingBox>
         <Greeting>
@@ -75,7 +77,7 @@ const My = () => {
 };
 
 const GreetingBox = tw.div`
-flex h-[60px] justify-between px-[16px]
+flex h-[50px] justify-between px-[16px]
 `;
 
 const Greeting = tw.div`

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -37,7 +37,7 @@ const My = () => {
       <NavBar centerTitle="마이페이지" isLeft={true} />
       <div className="mt-[73px] px-4">
         <TitleBadge
-          className="px-3 h-7 w-fit text-label2"
+          className="px-3 h-fit w-fit text-label2"
           name={user?.main_member_title as string}
         />
       </div>

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -37,7 +37,7 @@ const My = () => {
       <NavBar centerTitle="마이페이지" isLeft={true} />
       <div className="mt-[73px] px-4">
         <TitleBadge
-          className="px-3 h-fit w-fit text-label2"
+          className="h-fit w-fit px-3 py-1 text-label2"
           name={user?.main_member_title as string}
         />
       </div>

--- a/src/pages/my/titles.tsx
+++ b/src/pages/my/titles.tsx
@@ -13,6 +13,8 @@ export type ModalTitleType = {
   name: string | null;
   is_holding: boolean;
   is_main: boolean;
+  content: string | null;
+  standard: string | null;
 };
 
 const Titles = () => {
@@ -24,6 +26,8 @@ const Titles = () => {
     name: null,
     is_holding: false,
     is_main: false,
+    content: null,
+    standard: null,
   });
   const { data: titles } = useGetAllTitles();
 
@@ -33,6 +37,8 @@ const Titles = () => {
     name: string,
     is_holding: boolean,
     is_main: boolean,
+    content: string,
+    standard: string,
   ) => {
     setIsModal(true);
     setModalTitle({
@@ -41,6 +47,8 @@ const Titles = () => {
       name,
       is_holding,
       is_main,
+      content,
+      standard,
     });
   };
 
@@ -64,12 +72,28 @@ const Titles = () => {
         <span className="mx-4 mt-[28px] h-[1px] w-[327px] bg-bg-primary" />
         <AllTitles>
           {titles?.member_titles.map(
-            ({ id, image_url, name, is_holding, is_main }) => (
+            ({
+              id,
+              image_url,
+              name,
+              is_holding,
+              is_main,
+              content,
+              standard,
+            }) => (
               <div key={id} className="flex flex-col items-center">
                 {is_holding ? (
                   <TitleBox
                     onClick={() =>
-                      handleTitleClick(id, image_url, name, is_holding, is_main)
+                      handleTitleClick(
+                        id,
+                        image_url,
+                        name,
+                        is_holding,
+                        is_main,
+                        content,
+                        standard,
+                      )
                     }
                   >
                     <Image src={image_url} width={80} height={80} alt="칭호" />
@@ -78,7 +102,15 @@ const Titles = () => {
                   <TitleBox
                     className="border-line-disable"
                     onClick={() =>
-                      handleTitleClick(id, image_url, name, is_holding, is_main)
+                      handleTitleClick(
+                        id,
+                        image_url,
+                        name,
+                        is_holding,
+                        is_main,
+                        content,
+                        standard,
+                      )
                     }
                   >
                     <Image src={image_url} width={80} height={80} alt="칭호" />

--- a/src/pages/shopDetail/index.tsx
+++ b/src/pages/shopDetail/index.tsx
@@ -16,7 +16,7 @@ import { useGetShopDetail } from '@hooks/queries/useGetShop';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { userState } from '@recoil/userAtom';
 import { modalState } from '@recoil/modalAtom';
-import ShopTitle from '@components/common/ShopTitle';
+import ShopTitle from '@components/title/ShopTitle';
 
 const ShopDetail = () => {
   const router = useRouter();


### PR DESCRIPTION
## 🛠 작업 내용

대표칭호 컴포넌트 작성 및 적용

-  close #179
- close #182 

## PR 세부 내용
- 대표 칭호 컴포넌트 (TitleBadge)를 작성해서 필요한 페이지에 적용했습니다.
  - 자잘한 변동사항들이 많아서 TitleBadge, my/index.tsx, ReviewItem 위주로 보시면 될 것 같습니다.
- 지점 칭호(ShopTitle)을 common에서 title 폴더로 이동했습니다.
- 칭호 모달에 획득 방법 문구 추가했습니다.

<!--수정/추가한 작업 내용을 설명해주세요.-->

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
<img width="369" alt="image" src="https://github.com/4-frame-photos-map/frontend/assets/48711263/d1d24c50-21da-4d57-955a-60964330ade7">
<br />

<img width="389" alt="image" src="https://github.com/4-frame-photos-map/frontend/assets/48711263/a1958234-7cb9-4499-9fd7-8ec9802b19d3">


