### PR TITLE
fix: #183/ 내주변 페이지 특정 브랜드 필터링 상태에서 반경 조절시 전체 지점 받아오지 못하는 현상 수정

### DIFF
--- a/src/apis/shop/shop.d.ts
+++ b/src/apis/shop/shop.d.ts
@@ -17,7 +17,7 @@ type ShopProps = {
   longitude?: string;
   latitude?: string;
   distance: string;
-  place_url: string;
+  place_url?: string;
   star_rating_avg: number;
   review_cnt: number;
   favorite_cnt: number;
@@ -43,7 +43,6 @@ type ShopReviewProps = {
 };
 
 type BrandProps = {
-  id: number;
   brand_name: string;
   file_path: string;
 };

--- a/src/apis/shop/shopApi.ts
+++ b/src/apis/shop/shopApi.ts
@@ -17,11 +17,10 @@ class ShopApi {
     lng: number,
     mapLat: number,
     mapLng: number,
-    brd?: string,
     radius?: number,
   ): Promise<ShopInRad> => {
     const { data } = await instance.get(
-      `/shops/brand?userLat=${lat}&userLng=${lng}&mapLat=${mapLat}&mapLng=${mapLng}&brand=${brd}&radius=${radius}`,
+      `/shops/brand?userLat=${lat}&userLng=${lng}&mapLat=${mapLat}&mapLng=${mapLng}&radius=${radius}`,
     );
     return data;
   };

--- a/src/hooks/queries/useGetShop.ts
+++ b/src/hooks/queries/useGetShop.ts
@@ -23,12 +23,11 @@ export const useGetShopsInRad = (
   lng: number,
   mapLat: number,
   mapLng: number,
-  brd?: string,
   radius?: number,
 ) => {
   return useQuery<ShopInRad, Error>(
     ['useGetShopsInRad', mapLat, mapLng, radius],
-    () => shopApi.getShopsInRad(lat, lng, mapLat, mapLng, brd, radius),
+    () => shopApi.getShopsInRad(lat, lng, mapLat, mapLng, radius),
     {
       refetchOnWindowFocus: false,
       enabled: !!lat && !!mapLat,

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -40,7 +40,6 @@ const Home = () => {
     curPos.lng,
     location.lat,
     location.lng,
-    brd,
     2000,
   );
 

--- a/src/pages/location/index.tsx
+++ b/src/pages/location/index.tsx
@@ -33,7 +33,6 @@ const Location = () => {
     curPos.lng,
     curPos.lat,
     curPos.lng,
-    brd,
     radius,
   );
   useEffect(() => {

--- a/src/pages/location/index.tsx
+++ b/src/pages/location/index.tsx
@@ -110,15 +110,17 @@ const Location = () => {
             <div className="h-[1px] w-full bg-line-normal"></div>
           </div>
           <Category setBrd={setBrd} className="mt-0" />
-          {shopsInfo?.length === 0 && (
+          {shopsInfo?.length === 0 ? (
             <NoResultItemBox>
-              반경 5km 이내 포토부스가 <br />
-              존재하지 않습니다.
+              {`반경 ${
+                Number.isInteger(radius / 1000)
+                  ? `${radius / 1000}km`
+                  : `${radius}m`
+              } 이내 포토부스가\n존재하지 않습니다.`}
             </NoResultItemBox>
-          )}
-          <ResultItemBox>
-            {shopInfo &&
-              shopsInfo?.map((shop) => (
+          ) : (
+            <ResultItemBox>
+              {shopsInfo?.map((shop) => (
                 <ShopItem
                   key={shop.id}
                   brand_name={shop.brand?.brand_name as string}
@@ -133,7 +135,8 @@ const Location = () => {
                   shop_titles={shop.shop_titles}
                 />
               ))}
-          </ResultItemBox>
+            </ResultItemBox>
+          )}
         </ResultBox>
       </ResultContainer>
     </PageLayout>
@@ -156,7 +159,7 @@ const ResultItemBox = tw.div`
 grid w-full grid-cols-2 content-center items-center gap-2 pt-4 px-4
 `;
 const NoResultItemBox = tw.div`
-flex h-[250px] items-center justify-center px-4 text-center text-text-alternative
+flex h-full justify-center px-4 text-center text-text-alternative mt-[52px] whitespace-pre-line
 `;
 
 export default Location;

--- a/src/pages/location/index.tsx
+++ b/src/pages/location/index.tsx
@@ -159,7 +159,7 @@ const ResultItemBox = tw.div`
 grid w-full grid-cols-2 content-center items-center gap-2 pt-4 px-4
 `;
 const NoResultItemBox = tw.div`
-flex h-full justify-center px-4 text-center text-text-alternative mt-[52px] whitespace-pre-line
+flex h-full justify-center px-4 text-center text-text-alternative my-[52px] whitespace-pre-line
 `;
 
 export default Location;

--- a/src/pages/shopDetail/index.tsx
+++ b/src/pages/shopDetail/index.tsx
@@ -82,7 +82,7 @@ const ShopDetail = () => {
       <ShopInfoBox>
         <ShopTagBox>
           <BrandTag name={shopInfo?.place_name as string} />
-          <div className="flex ml-2">
+          <div className="ml-2 flex">
             {shopInfo?.shop_titles &&
               shopInfo?.shop_titles?.map((title, idx) => (
                 <ShopTitle key={idx} title={title} width={70} height={20} />
@@ -96,7 +96,7 @@ const ShopDetail = () => {
             <div className="pl-1 pr-2">
               {shopInfo?.star_rating_avg} ({shopInfo?.review_cnt})
             </div>
-            <div className="px-2 border-l border-text-alternative">
+            <div className="border-l border-text-alternative px-2">
               <span>찜</span>
               <span className="pl-1 font-semibold">
                 {shopInfo?.favorite_cnt}
@@ -108,7 +108,7 @@ const ShopDetail = () => {
         <ShopEventBox>
           <ShopEvent
             onClick={() => {
-              if (shopInfo) {
+              if (shopInfo && shopInfo.place_url) {
                 router.push(shopInfo.place_url);
               }
             }}


### PR DESCRIPTION
## 🛠 작업 내용

close #183 

- 기존 반경 내 지점 조회 api 사용시 옵셔널 파라미터인 brand 값을 포함해 요청을 하고있었는데, 현재 로직 상 전체 조회 결과를 받아와 자체적으로 브랜드 state를 통해 필터링을 진행하고 있어서, 해당 파라미터를 삭제했습니다.
- place_url과 brand_id 응답 값에대한 수정사항 반영했습니다.
- 반경 조절 시 검색 결과 없을 때 텍스트를 수정했습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
