### PR TITLE
refactor: #189/칭호 수정사항 반영

### DIFF
--- a/src/components/title/TitleModal.tsx
+++ b/src/components/title/TitleModal.tsx
@@ -10,12 +10,11 @@ type TitleModalProps = {
 };
 
 const TitleModal = ({ setIsModal, title }: TitleModalProps) => {
-  const { id, image_url, name, is_holding, is_main, content, standard } = title;
+  const { id, image_url, name, is_holding, content, standard } = title;
   const { mutate } = usePatchTitle(
     id as number,
     image_url as string,
     name as string,
-    is_main,
   );
 
   const handleOverlayClick = () => {

--- a/src/components/title/TitleModal.tsx
+++ b/src/components/title/TitleModal.tsx
@@ -10,11 +10,12 @@ type TitleModalProps = {
 };
 
 const TitleModal = ({ setIsModal, title }: TitleModalProps) => {
-  const { id, image_url, name, is_holding, content, standard } = title;
+  const { id, image_url, name, is_holding, is_main, content, standard } = title;
   const { mutate } = usePatchTitle(
     id as number,
     image_url as string,
     name as string,
+    is_main,
   );
 
   const handleOverlayClick = () => {
@@ -66,7 +67,7 @@ const TitleModal = ({ setIsModal, title }: TitleModalProps) => {
             />
           </ActiveButton>
         ) : (
-          <DisabledButton onClick={() => handleButtonClick(id as number)}>
+          <DisabledButton>
             <span className="text-center text-[18px]">
               나의 대표 칭호로 사용하기
             </span>

--- a/src/hooks/mutations/usePatchTitle.ts
+++ b/src/hooks/mutations/usePatchTitle.ts
@@ -2,7 +2,12 @@ import memberApi from '@apis/member/memberApi';
 import { queryClient } from 'pages/_app';
 import { useMutation } from 'react-query';
 
-export const usePatchTitle = (id: number, image_url: string, name: string) => {
+export const usePatchTitle = (
+  id: number,
+  image_url: string,
+  name: string,
+  is_main: boolean,
+) => {
   return useMutation<void, void, number, unknown>(
     'usePatchTitle',
     (titleId: number) => memberApi.patchTitle(titleId),
@@ -14,6 +19,18 @@ export const usePatchTitle = (id: number, image_url: string, name: string) => {
         queryClient.setQueryData<MemberTitle[]>(
           ['useGetAllTitles'],
           (old: any) => {
+            const newMainTitle = old.member_titles.map((title) => {
+              if (title.id === id) {
+                return {
+                  ...title,
+                  is_main: true,
+                };
+              }
+              return {
+                ...title,
+                is_main: false,
+              };
+            });
             return {
               ...old,
               main_member_title: {
@@ -21,7 +38,9 @@ export const usePatchTitle = (id: number, image_url: string, name: string) => {
                 id,
                 image_url,
                 name,
+                is_main,
               },
+              member_titles: newMainTitle,
             };
           },
         );

--- a/src/hooks/mutations/usePatchTitle.ts
+++ b/src/hooks/mutations/usePatchTitle.ts
@@ -2,12 +2,7 @@ import memberApi from '@apis/member/memberApi';
 import { queryClient } from 'pages/_app';
 import { useMutation } from 'react-query';
 
-export const usePatchTitle = (
-  id: number,
-  image_url: string,
-  name: string,
-  is_main: boolean,
-) => {
+export const usePatchTitle = (id: number, image_url: string, name: string) => {
   return useMutation<void, void, number, unknown>(
     'usePatchTitle',
     (titleId: number) => memberApi.patchTitle(titleId),

--- a/src/hooks/mutations/usePatchTitle.ts
+++ b/src/hooks/mutations/usePatchTitle.ts
@@ -35,10 +35,8 @@ export const usePatchTitle = (
               ...old,
               main_member_title: {
                 ...old.main_member_title,
-                id,
                 image_url,
                 name,
-                is_main,
               },
               member_titles: newMainTitle,
             };

--- a/src/pages/my/titles.tsx
+++ b/src/pages/my/titles.tsx
@@ -83,21 +83,50 @@ const Titles = () => {
             }) => (
               <div key={id} className="flex flex-col items-center">
                 {is_holding ? (
-                  <TitleBox
-                    onClick={() =>
-                      handleTitleClick(
-                        id,
-                        image_url,
-                        name,
-                        is_holding,
-                        is_main,
-                        content,
-                        standard,
-                      )
-                    }
-                  >
-                    <Image src={image_url} width={80} height={80} alt="칭호" />
-                  </TitleBox>
+                  is_main ? (
+                    <TitleBox
+                      className="border-[2px] border-[#FF5A5A]"
+                      onClick={() =>
+                        handleTitleClick(
+                          id,
+                          image_url,
+                          name,
+                          is_holding,
+                          is_main,
+                          content,
+                          standard,
+                        )
+                      }
+                    >
+                      <Image
+                        src={image_url}
+                        width={80}
+                        height={80}
+                        alt="칭호"
+                      />
+                    </TitleBox>
+                  ) : (
+                    <TitleBox
+                      onClick={() =>
+                        handleTitleClick(
+                          id,
+                          image_url,
+                          name,
+                          is_holding,
+                          is_main,
+                          content,
+                          standard,
+                        )
+                      }
+                    >
+                      <Image
+                        src={image_url}
+                        width={80}
+                        height={80}
+                        alt="칭호"
+                      />
+                    </TitleBox>
+                  )
                 ) : (
                   <TitleBox
                     className="border-line-disable"


### PR DESCRIPTION
## 🛠 작업 내용

- close #189 

## PR 세부 내용

<!--수정/추가한 작업 내용을 설명해주세요.-->
- 획득하지 않은 칭호일 때 대표 칭호 설정 onClick 이벤트를 삭제했습니다.
- 대표 칭호 여부를 구분해서 테두리 굵기 및 색상에 변화를 주었습니다.
  - 해당 수정사항에 따라 칭호 목록 중 대표 칭호 여부를 낙관적으로 업데이트 하도록 수정했습니다.

## 📸 스크린샷 or GIF

<img width="307" alt="image" src="https://github.com/4-frame-photos-map/frontend/assets/48711263/f090d20c-bcc7-406c-81b9-c0e0709a7c45">
<!--스크린샷 또는 GIF를 첨부해주세요.-->
