### PR TITLE
refactor: #191/ 내주변 페이지 지도 정방향 수정 및 next link 사용

### DIFF
--- a/src/components/common/Map.tsx
+++ b/src/components/common/Map.tsx
@@ -157,8 +157,8 @@ const Map = ({
     <>
       <div
         className={`${
-          isHome ? 'absolute h-full' : 'fixed h-[500px]'
-        } top-0 z-0 w-full max-w-[375px]`}
+          isHome ? 'absolute h-full' : 'fixed h-[375px]'
+        } top-0 z-0 mt-[68px] w-full max-w-[375px]`}
         ref={mapContainer}
       ></div>
     </>

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -2,7 +2,6 @@ import tw from 'tailwind-styled-components';
 import Link from 'next/link';
 import Image from 'next/image';
 import { CONFIG } from '@config';
-import { ReactNode } from 'react';
 
 type ModalProps = {
   isModal?: boolean;

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -207,11 +207,11 @@ const NavItems = tw.div`
 mx-4 flex items-center justify-between h-full pt-1
 `;
 
-const LeftTitle = tw.span`
+const LeftTitle = tw.h1`
 text-title2 font-semibold
 `;
 
-const CenterTitle = tw.span`
+const CenterTitle = tw.h1`
 absolute inset-x-0 mx-0 my-auto text-center text-title2 font-semibold
 `;
 

--- a/src/components/home/ShopModal.tsx
+++ b/src/components/home/ShopModal.tsx
@@ -1,12 +1,13 @@
 import Image from 'next/image';
 import BrandTag from '@components/common/BrandTag';
+import ShopTitle from '@components/title/ShopTitle';
+import Link from 'next/link';
 import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
 import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
 import { useRouter } from 'next/router';
 import { useGetShopDetail } from '@hooks/queries/useGetShop';
 import { SetterOrUpdater, useRecoilValue } from 'recoil';
 import { curPosState } from '@recoil/positionAtom';
-import ShopTitle from '@components/title/ShopTitle';
 
 type ShopModalProps = {
   id: number;
@@ -57,12 +58,9 @@ const ShopModal = ({
           </div>
         </div>
         <div className="flex justify-between pt-1 pb-2">
-          <span
-            className="text-label1"
-            onClick={() => router.push(`/shopDetail/?shopId=${id}`)}
-          >
-            {place_name}
-          </span>
+          <Link href={`/shopDetail/?shopId=${id}`} passHref>
+            <span className="text-label1">{place_name}</span>
+          </Link>
           {shopInfo?.favorite ? (
             <Image
               src="/svg/wish/filled-bookmark.svg"

--- a/src/components/location/ShopItem.tsx
+++ b/src/components/location/ShopItem.tsx
@@ -51,72 +51,70 @@ const ShopItem = ({
     }
   };
   return (
-    <>
-      <ItemContainer
-        onClick={() => {
-          router.push(`/shopDetail/?shopId=${id}`);
-        }}
-      >
-        <ItemImgContainer>
-          <Image
-            className="rounded-lg"
-            src={`${file_path}`}
-            alt={brand_name}
-            fill
-          />
-          <FavoriteBtn>
-            {shopInfo?.favorite ? (
-              <div className="flex h-[28px] w-[28px] items-center justify-center rounded bg-[rgba(79,79,79,0.1)]">
-                <Image
-                  src="/svg/wish/filled-bookmark.svg"
-                  width={24}
-                  height={24}
-                  alt="wish"
-                  onClick={(e) => {
-                    handleFavorite(e, id);
-                  }}
-                />
-              </div>
-            ) : (
-              <div className="flex h-[28px] w-[28px] items-center justify-center rounded bg-[rgba(79,79,79,0.1)]">
-                <Image
-                  src="/svg/wish/lined-bookmark.svg"
-                  width={24}
-                  height={24}
-                  alt="wish"
-                  className="cursor-pointer"
-                  onClick={(e) => handleFavorite(e, id)}
-                />
-              </div>
-            )}
-          </FavoriteBtn>
-        </ItemImgContainer>
-        <span className="truncate text-label1">{place_name}</span>
-        <ItemDescBox>
-          <span className="flex pr-2">
-            <Image src="/svg/star.svg" width={16} height={16} alt="star" />
-            {star_rating} ({review_cnt})
+    <ItemContainer
+      onClick={() => {
+        router.push(`/shopDetail/?shopId=${id}`);
+      }}
+    >
+      <ItemImgContainer>
+        <Image
+          className="rounded-lg"
+          src={`${file_path}`}
+          alt={brand_name}
+          fill
+        />
+        <FavoriteBtn>
+          {shopInfo?.favorite ? (
+            <div className="flex h-[28px] w-[28px] items-center justify-center rounded bg-[rgba(79,79,79,0.1)]">
+              <Image
+                src="/svg/wish/filled-bookmark.svg"
+                width={24}
+                height={24}
+                alt="wish"
+                onClick={(e) => {
+                  handleFavorite(e, id);
+                }}
+              />
+            </div>
+          ) : (
+            <div className="flex h-[28px] w-[28px] items-center justify-center rounded bg-[rgba(79,79,79,0.1)]">
+              <Image
+                src="/svg/wish/lined-bookmark.svg"
+                width={24}
+                height={24}
+                alt="wish"
+                className="cursor-pointer"
+                onClick={(e) => handleFavorite(e, id)}
+              />
+            </div>
+          )}
+        </FavoriteBtn>
+      </ItemImgContainer>
+      <span className="truncate text-label1">{place_name}</span>
+      <ItemDescBox>
+        <span className="flex pr-2">
+          <Image src="/svg/star.svg" width={16} height={16} alt="star" />
+          {star_rating} ({review_cnt})
+        </span>
+        <div className="border-l pl-2">
+          <span className="pr-1">찜</span>
+          <span className="font-semibold">{shopInfo?.favorite_cnt}</span>
+          <span className="ml-9 text-caption1 text-text-alternative">
+            {shopInfo?.distance}
           </span>
-          <div className="border-l pl-2">
-            <span className="pr-1">찜</span>
-            <span className="font-semibold">{shopInfo?.favorite_cnt}</span>
-            <span className="ml-9 text-caption1 text-text-alternative">
-              {shopInfo?.distance}
-            </span>
-          </div>
-        </ItemDescBox>
-        <div className="relative flex pt-2">
-          {shopInfo?.shop_titles &&
-            shopInfo?.shop_titles?.map((title, idx) => (
-              <ShopTitle key={idx} title={title} width={65} height={20} />
-            ))}
         </div>
-      </ItemContainer>
-    </>
+      </ItemDescBox>
+      <div className="relative flex pt-2">
+        {shopInfo?.shop_titles &&
+          shopInfo?.shop_titles?.map((title, idx) => (
+            <ShopTitle key={idx} title={title} width={65} height={20} />
+          ))}
+      </div>
+    </ItemContainer>
   );
 };
 
-const ItemContainer = tw.div`
+const ItemContainer = tw.li`
 flex flex-col cursor-pointer relative pb-3 self-start
 `;
 const FavoriteBtn = tw.div`

--- a/src/components/my/SettingItem.tsx
+++ b/src/components/my/SettingItem.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import tw from 'tailwind-styled-components';
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 import React from 'react';
 
 interface SettingItemProps {
@@ -13,20 +13,17 @@ interface DefaultProps {
   className?: React.ComponentProps<'div'>['className'];
 }
 
-const SettingItemBox = tw.div<DefaultProps>`
-flex flex-col justify-center items-center cursor-pointer w-[74px]
-`;
-
-export default function Activity({ text, path, icon }: SettingItemProps) {
-  const router = useRouter();
+export default function SettingItem({ text, path, icon }: SettingItemProps) {
   return (
-    <SettingItemBox
-      onClick={() => {
-        router.push(`${path}`);
-      }}
-    >
-      <Image src={icon} alt={`${icon}`} width={32} height={20} />
-      <span className="mt-1 text-caption1 font-normal">{text}</span>
+    <SettingItemBox>
+      <Link href={path}>
+        <Image src={icon} alt={`${icon}`} width={32} height={20} />
+        <span className="mt-1 text-caption1 font-normal">{text}</span>
+      </Link>
     </SettingItemBox>
   );
 }
+
+const SettingItemBox = tw.li<DefaultProps>`
+flex flex-col justify-center items-center cursor-pointer w-[74px]
+`;

--- a/src/components/my/SettingList.tsx
+++ b/src/components/my/SettingList.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 interface SettingItemProps {
   text: string;
@@ -7,14 +7,12 @@ interface SettingItemProps {
 }
 
 export default function SettingList({ text, path }: SettingItemProps) {
-  const router = useRouter();
   return (
-    <div
-      onClick={() => router.push(`${path}`)}
-      className="flex justify-between py-[8px]"
-    >
-      <span>{text}</span>
-      <Image src={'/svg/right.svg'} width={24} height={24} alt="arrow" />
-    </div>
+    <li>
+      <Link href={path} className="flex justify-between py-[8px]">
+        {text}
+        <Image src={'/svg/right.svg'} width={24} height={24} alt="arrow" />
+      </Link>
+    </li>
   );
 }

--- a/src/components/navbar/SearchList.tsx
+++ b/src/components/navbar/SearchList.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import tw from 'tailwind-styled-components';
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 type SearchListProps = Shop & {
   isList: boolean;
@@ -16,47 +16,44 @@ const SearchList = ({
   isList,
   id,
 }: SearchListProps) => {
-  const router = useRouter();
   return isList ? (
     <>
-      <DivisionBar />
-      <li
-        className="px-3 py-2 bg-white cursor-pointer"
-        onClick={() => router.push(`/shopDetail/?shopId=${id}`)}
-      >
-        <span className="text-label1">{place_name}</span>
-        <div className="flex gap-x-1">
-          <Image
-            src="/svg/navbar/gray-star.svg"
-            width={12}
-            height={12}
-            alt="star"
-          />
-          <span className="text-caption1 text-text-alternative">
-            {star_rating_avg.toFixed(1)}
+      <ResultItem>
+        <Link href={`/shopDetail/?shopId=${id}`}>
+          <span className="text-label1">{place_name}</span>
+          <div className="flex gap-x-1">
+            <Image
+              src="/svg/navbar/gray-star.svg"
+              width={12}
+              height={12}
+              alt="star"
+            />
             <span className="text-caption1 text-text-alternative">
-              {' '}
-              ({review_cnt})
-            </span>{' '}
-            | 찜{' '}
-            <span className="text-caption1 text-text-alternative">
-              {favorite_cnt}
+              {star_rating_avg.toFixed(1)}
+              <span className="text-caption1 text-text-alternative">
+                {' '}
+                ({review_cnt})
+              </span>{' '}
+              | 찜{' '}
+              <span className="text-caption1 text-text-alternative">
+                {favorite_cnt}
+              </span>
             </span>
-          </span>
-        </div>
-        <div className="flex items-center mt-2 gap-x-1">
-          <span className="text-caption2">{distance}</span>
-          <span className="text-caption1 text-text-alternative">
-            | {place_address}
-          </span>
-        </div>
-      </li>
+          </div>
+          <div className="mt-2 flex items-center gap-x-1">
+            <span className="text-caption2">{distance}</span>
+            <span className="text-caption1 text-text-alternative">
+              | {place_address}
+            </span>
+          </div>
+        </Link>
+      </ResultItem>
     </>
   ) : null;
 };
 
-const DivisionBar = tw.div`
-flex justify-center h-[1px] w-full bg-line-alternative mx-2 first:mt-5
+const ResultItem = tw.li`
+cursor-pointer border-t-[1px] border-line-alternative bg-white px-3 py-2 first:mt-5
 `;
 
 export default SearchList;

--- a/src/components/navbar/SearchResult.tsx
+++ b/src/components/navbar/SearchResult.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import tw from 'tailwind-styled-components';
 import TextHighlighted from '@components/navbar/TextHighlighted';
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 type SearchProps = Shop & {
   value: string;
@@ -16,34 +16,34 @@ const SearchResult = ({
   distance,
   place_address,
 }: SearchProps) => {
-  const router = useRouter();
   const [initial, ...rest] = place_name.split(value);
   return isTyping ? (
     <li className="cursor-pointer bg-white px-3 first:pt-5">
       <DivisionBar />
       {
-        <div
-          className="flex items-center"
-          onClick={() => router.push(`/shopDetail/?shopId=${id}`)}
-        >
-          <div className="flex flex-col items-center">
-            <Image
-              src="/svg/navbar/location.svg"
-              width={20}
-              height={20}
-              alt="distance"
-            />
-            <span className="text-caption2 text-line-disable">{distance}</span>
-          </div>
-          <div className="ml-4 flex flex-col">
-            <div className="flex">
-              <TextHighlighted value={value} initial={initial} rest={rest} />
+        <Link href={`/shopDetail/?shopId=${id}`}>
+          <div className="flex items-center">
+            <div className="flex flex-col items-center">
+              <Image
+                src="/svg/navbar/location.svg"
+                width={20}
+                height={20}
+                alt="distance"
+              />
+              <span className="text-caption2 text-line-disable">
+                {distance}
+              </span>
             </div>
-            <span className="text-caption1 text-text-alternative">
-              {place_address}
-            </span>
+            <div className="ml-4 flex flex-col">
+              <div className="flex">
+                <TextHighlighted value={value} initial={initial} rest={rest} />
+              </div>
+              <span className="text-caption1 text-text-alternative">
+                {place_address}
+              </span>
+            </div>
           </div>
-        </div>
+        </Link>
       }
     </li>
   ) : null;

--- a/src/components/wish/WishItem.tsx
+++ b/src/components/wish/WishItem.tsx
@@ -1,15 +1,14 @@
+import tw from 'tailwind-styled-components';
 import BrandTag from '@components/common/BrandTag';
 import Modal from '@components/common/Modal';
 import ToastMessage from '@components/common/ToastMessage';
+import Image from 'next/image';
+import Link from 'next/link';
 import { useDeleteFavorite } from '@hooks/mutations/useDeleteFavorite';
 import { usePostFavorite } from '@hooks/mutations/usePostFavorite';
-import Image from 'next/image';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
-import tw from 'tailwind-styled-components';
 
 const WishItem = ({ shop }: Favorite) => {
-  const router = useRouter();
   const [isModal, setIsModal] = useState<boolean>(false);
   const [toast, setToast] = useState<boolean>(false);
   const { mutate: del, isSuccess, isError } = useDeleteFavorite('/wish');
@@ -28,11 +27,10 @@ const WishItem = ({ shop }: Favorite) => {
       <li className="w-full bg-white px-6 py-5">
         <BrandTag name={shop.place_name} />
         <div className="flex justify-between pt-1 pb-2">
-          <span
-            className="cursor-pointer text-body1"
-            onClick={() => router.push(`/shopDetail/?shopId=${shop.id}`)}
-          >
-            {shop.place_name}
+          <span className="cursor-pointer text-body1">
+            <Link href={`/shopDetail/?shopId=${shop.id}`}>
+              {shop.place_name}
+            </Link>
           </span>
           {shop.id ? (
             <Image

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -98,7 +98,7 @@ const Faq = () => {
 };
 
 const CategoryBar = tw.div`
-fixed bg-white py-8
+fixed bg-white py-8 max-w-[375px]
 `;
 const ItemsWrapper = tw.ul`
 flex items-center px-6

--- a/src/pages/location/index.tsx
+++ b/src/pages/location/index.tsx
@@ -83,7 +83,7 @@ const Location = () => {
         setCurPos={setCurPos}
         setBounds={setBounds}
       />
-      <div className="fixed top-[430px] w-full max-w-[375px] pb-[71px]">
+      <div className="fixed top-[385px] w-full max-w-[375px]">
         <TrackerButton onClick={handleTracker} />
       </div>
       <ResultContainer>
@@ -144,7 +144,7 @@ const Location = () => {
 };
 
 const ResultContainer = tw.div`
-mt-[500px] mb-10 h-full w-full bg-white relative items-start
+mt-[440px] mb-10 h-full w-full bg-white relative items-start
 `;
 const ResultBox = tw.div`
 h-full rounded-t-[15px] pt-2 pb-10
@@ -155,7 +155,7 @@ m-auto flex h-1 w-[60px] justify-center rounded-sm bg-line-normal
 const RadSelectBox = tw.div`
 mt-4 flex gap-2 px-4 text-body1 font-semibold
 `;
-const ResultItemBox = tw.div`
+const ResultItemBox = tw.ul`
 grid w-full grid-cols-2 content-center items-center gap-2 pt-4 px-4
 `;
 const NoResultItemBox = tw.div`

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -4,9 +4,9 @@ import NavBar from '@components/common/NavBar';
 import PageLayout from '@components/layout/PageLayout';
 import SettingItem from '@components/my/SettingItem';
 import SettingList from '@components/my/SettingList';
-import { useGetProfile } from '@hooks/queries/useGetProfile';
-import { useRouter } from 'next/router';
 import TitleBadge from '@components/title/TitleBadge';
+import Link from 'next/link';
+import { useGetProfile } from '@hooks/queries/useGetProfile';
 
 export type SettingListsProps = {
   id: number;
@@ -26,11 +26,9 @@ const SettingItems: SettingItemsProps[] = [
 
 const SettingLists: SettingListsProps[] = [
   { id: 1, text: '문의사항', path: '/faq' },
-  { id: 2, text: '약관 확인', path: '/notice' },
 ];
 
 const My = () => {
-  const router = useRouter();
   const { data: user } = useGetProfile();
   return (
     <PageLayout className="bg-white">
@@ -49,15 +47,17 @@ const My = () => {
           </div>
         </Greeting>
         <div className="flex items-center">
-          <SettingBox onClick={() => router.push('/my/setting')}>
-            <Image
-              src={'/svg/setting.svg'}
-              width={18}
-              height={18}
-              alt="setting"
-            />
-            <span className="flex items-center text-caption2">설정</span>
-          </SettingBox>
+          <Link href={'/my/setting'}>
+            <SettingBox>
+              <Image
+                src={'/svg/setting.svg'}
+                width={18}
+                height={18}
+                alt="setting"
+              />
+              <span className="flex items-center text-caption2">설정</span>
+            </SettingBox>
+          </Link>
         </div>
       </GreetingBox>
       <ItemsContainer>
@@ -88,11 +88,11 @@ const SettingBox = tw.div`
 flex cursor-pointer rounded-xl border bg-bg-tertiary p-1
 `;
 
-const ItemsContainer = tw.div`
+const ItemsContainer = tw.ul`
 flex w-full justify-between px-[16px] py-[24px]
 `;
 
-const ListsContainer = tw.div`
+const ListsContainer = tw.ul`
 flex cursor-pointer flex-col px-[16px] text-body2 font-normal
 `;
 

--- a/src/pages/my/setting.tsx
+++ b/src/pages/my/setting.tsx
@@ -11,8 +11,6 @@ import memberApi from '@apis/member/memberApi';
 
 const SettingLists: SettingListsProps[] = [
   { id: 1, text: '닉네임 변경', path: '/my/edit' },
-  { id: 2, text: '이용약관 확인', path: '/terms' },
-  { id: 3, text: '개인정보 처리방침 확인', path: '/' },
 ];
 
 const Setting = () => {


### PR DESCRIPTION
## 🛠 작업 내용

- 내 주변 페이지의 지도를 정방향으로 수정했습니다.
- 애플리케이션 seo향상을 위해 특정 로직을 제외하고 next/Router 대신 next/Link를 사용하도록 수정했습니다.
- my 페이지에서 약관 관련 리스트를 삭제했습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
