### PR TITLE
refactor: #193/ seo 컴포넌트 구현

### DIFF
--- a/src/components/common/Seo.tsx
+++ b/src/components/common/Seo.tsx
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+
+type SeoProps = {
+  title: string;
+  url: string;
+};
+
+const Seo = ({ title, url }: SeoProps) => {
+  return (
+    <Head>
+      <title>{`${title} | 네컷지도`}</title>
+      <meta name="og:title" content={`${title} | 네컷지도`} />
+      <meta name="og:url" content={`https://photosmap.vercel.app/${url}`} />
+      <meta name="viewport" content="width=device-width" />
+    </Head>
+  );
+};
+
+export default Seo;

--- a/src/components/common/SplashLogin.tsx
+++ b/src/components/common/SplashLogin.tsx
@@ -1,8 +1,18 @@
 import Image from 'next/image';
 
-const SplashLogin = () => {
+type SplashLoginProps = {
+  loading: boolean;
+};
+
+const SplashLogin = ({ loading }: SplashLoginProps) => {
   return (
-    <div className="flex flex-col items-center">
+    <div
+      className={`${
+        loading
+          ? 'flex h-screen animate-[pulse_2.5s_ease-in-out_infinite] flex-col items-center justify-center'
+          : 'hidden'
+      }`}
+    >
       <div className="relative mt-[100px] flex flex-col items-center">
         <Image
           src="/svg/login/pin-badge-skyblue.svg"

--- a/src/components/my/SettingItem.tsx
+++ b/src/components/my/SettingItem.tsx
@@ -16,7 +16,7 @@ interface DefaultProps {
 export default function SettingItem({ text, path, icon }: SettingItemProps) {
   return (
     <SettingItemBox>
-      <Link href={path}>
+      <Link href={path} className="flex flex-col items-center justify-center">
         <Image src={icon} alt={`${icon}`} width={32} height={20} />
         <span className="mt-1 text-caption1 font-normal">{text}</span>
       </Link>

--- a/src/components/my/SettingList.tsx
+++ b/src/components/my/SettingList.tsx
@@ -8,7 +8,7 @@ interface SettingItemProps {
 
 export default function SettingList({ text, path }: SettingItemProps) {
   return (
-    <li>
+    <li className="list-none">
       <Link href={path} className="flex justify-between py-[8px]">
         {text}
         <Image src={'/svg/right.svg'} width={24} height={24} alt="arrow" />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,7 +7,6 @@ import { getLocalStorage } from '@utils/localStorage';
 import { useRouter } from 'next/router';
 import { Hydrate, QueryClient, QueryClientProvider } from 'react-query';
 import { RecoilRoot } from 'recoil';
-import Head from 'next/head';
 
 declare global {
   interface Window {
@@ -42,9 +41,6 @@ export default function App({ Component, pageProps }: AppProps) {
   }
   return (
     <>
-      <Head>
-        <title>네컷 지도</title>
-      </Head>
       <RecoilRoot>
         <QueryClientProvider client={queryClient}>
           <Hydrate state={pageProps.dehydratedState}>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,20 +5,19 @@ export default function Document() {
     <Html lang="ko">
       <Head>
         <meta
-          name="viewport"
-          content="initial-scale=1.0, width=device-width, maximum-scale=1.0, user-scalable=no"
-        />
-        <meta
           name="description"
-          content="나와 가까운 네컷 사진 포토부스를 찾아보세요, 네컷 지도"
+          content="네컷지도에서 나와 가까운 네컷 사진 포토부스를 찾아보세요."
         />
+        <meta name="keywords" content="네컷지도" />
         <meta
           name="og:description"
-          content="나와 가까운 네컷 사진 포토부스를 찾아보세요. 네컷 지도"
+          content="네컷지도에서 나와 가까운 네컷 사진 포토부스를 찾아보세요."
         />
-        <meta property="og:title" content="네컷지도" />
         <meta property="og:type" content="website" />
-        <meta property="og:article:author" content="네컷지도" />
+        <meta
+          property="og:image"
+          content="https://d18tllc1sxg8cp.cloudfront.net/logo/main_logo.png"
+        />
         <link
           href="https://webfontworld.github.io/pretendard/Pretendard.css"
           rel="stylesheet"

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -1,10 +1,10 @@
 import Modal from '@components/common/Modal';
 import SplashLogin from '@components/common/SplashLogin';
 import AuthLayout from '@components/layout/AuthLayout';
+import Image from 'next/image';
+import Seo from '@components/common/Seo';
 import { CONFIG } from '@config';
 import { deleteToken } from '@utils/token';
-import Image from 'next/image';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
@@ -37,12 +37,10 @@ const Login = () => {
     return () => clearTimeout(timer);
   }, []);
 
-  return loading ? (
+  return (
     <AuthLayout>
-      <SplashLogin />
-    </AuthLayout>
-  ) : (
-    <AuthLayout>
+      <SplashLogin loading={loading} />
+      <Seo title="로그인" url="auth/login" />
       <Image
         src="/svg/login/login-logo.svg"
         alt="logo"
@@ -50,7 +48,7 @@ const Login = () => {
         height={48}
         priority={true}
       />
-      <Link
+      <a
         href={
           CONFIG.ENV === 'development'
             ? `https://kauth.kakao.com/oauth/authorize?client_id=${CONFIG.API_KEYS.LOGIN}&redirect_uri=${CONFIG.LOCAL}/auth/kakao&response_type=code`
@@ -62,7 +60,7 @@ const Login = () => {
         <p className="cursor-pointer whitespace-nowrap text-label2 leading-[17px] text-black">
           카카오 로그인
         </p>
-      </Link>
+      </a>
 
       <div
         onClick={() => {

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -7,6 +7,7 @@ import 'swiper/css';
 import { FAQ_LIST } from '@utils/faqLists';
 import { useEffect, useState } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import Seo from '@components/common/Seo';
 
 type FaqCategoryProps = {
   id: number;
@@ -40,6 +41,7 @@ const Faq = () => {
 
   return (
     <PageLayout className="pt-[68px] pb-[58px]">
+      <Seo title="문의사항" url="faq" />
       {isModal && faqInfo && (
         <FaqModal
           title={faqInfo.title}

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -13,6 +13,7 @@ import { curPosState } from '@recoil/positionAtom';
 import { boundState } from '@recoil/boundAtom';
 import { userState } from '@recoil/userAtom';
 import { modalState } from '@recoil/modalAtom';
+import Seo from '@components/common/Seo';
 
 RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
 
@@ -84,6 +85,7 @@ const Home = () => {
 
   return (
     <PageLayout>
+      <Seo title="홈" url="home" />
       <NavBar
         leftTitle={shopInfo?.address}
         isRight={true}

--- a/src/pages/location/index.tsx
+++ b/src/pages/location/index.tsx
@@ -14,6 +14,7 @@ import { curPosState } from '@recoil/positionAtom';
 import { boundState } from '@recoil/boundAtom';
 import { userState } from '@recoil/userAtom';
 import { modalState } from '@recoil/modalAtom';
+import Seo from '@components/common/Seo';
 
 const Location = () => {
   const isLogin = useRecoilValue<boolean>(userState);
@@ -60,6 +61,7 @@ const Location = () => {
   };
   return (
     <PageLayout className="bg-white">
+      <Seo title="내 주변" url="location" />
       {isRadModal && (
         <RadiusModal
           setIsModal={setIsRadModal}

--- a/src/pages/my/edit.tsx
+++ b/src/pages/my/edit.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form';
 import tw from 'tailwind-styled-components';
 import useDebounce from '@hooks/useDebounce';
 import { usePatchProfile } from '@hooks/mutations/usePatchProfile';
+import Seo from '@components/common/Seo';
 
 type FormValue = {
   nickname: string;
@@ -38,6 +39,7 @@ const Edit = () => {
   };
   return (
     <PageLayout className="bg-white">
+      <Seo title="닉네임 변경" url="my/edit" />
       <NavBar centerTitle="닉네임 변경" isLeft={true} />
       <EditContainer>
         <EditLabel>변경할 닉네임</EditLabel>

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -7,6 +7,7 @@ import SettingList from '@components/my/SettingList';
 import TitleBadge from '@components/title/TitleBadge';
 import Link from 'next/link';
 import { useGetProfile } from '@hooks/queries/useGetProfile';
+import Seo from '@components/common/Seo';
 
 export type SettingListsProps = {
   id: number;
@@ -32,6 +33,7 @@ const My = () => {
   const { data: user } = useGetProfile();
   return (
     <PageLayout className="bg-white">
+      <Seo title="마이페이지" url="my" />
       <NavBar centerTitle="마이페이지" isLeft={true} />
       <div className="mt-[73px] px-4">
         <TitleBadge

--- a/src/pages/my/reviews/edit.tsx
+++ b/src/pages/my/reviews/edit.tsx
@@ -9,6 +9,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import Seo from '@components/common/Seo';
 
 type ReviewForm = {
   star_rating?: number;
@@ -66,6 +67,7 @@ const Edit = () => {
 
   return (
     <ShopLayout className="bg-white">
+      <Seo title="리뷰 수정" url="my/reviews/edit" />
       <RatingContainer>
         <span className="pb-6 text-title2 font-semibold">이용 리뷰 작성</span>
         <div className="flex text-label2">

--- a/src/pages/my/reviews/index.tsx
+++ b/src/pages/my/reviews/index.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import tw from 'tailwind-styled-components';
 import BrandTag from '@components/common/BrandTag';
+import Seo from '@components/common/Seo';
 
 const Reviews = () => {
   const router = useRouter();
@@ -18,6 +19,7 @@ const Reviews = () => {
   const { mutate: deleteReview } = useDeleteReview();
   return (
     <PageLayout className="bg-bg-primary">
+      <Seo title="내 리뷰" url="my/reviews" />
       {isModal && (
         <ModalLayout>
           <Modal

--- a/src/pages/my/setting.tsx
+++ b/src/pages/my/setting.tsx
@@ -8,6 +8,7 @@ import NavBar from '@components/common/NavBar';
 import Modal from '@components/common/Modal';
 import authApi from '@apis/auth/authApi';
 import memberApi from '@apis/member/memberApi';
+import Seo from '@components/common/Seo';
 
 const SettingLists: SettingListsProps[] = [
   { id: 1, text: '닉네임 변경', path: '/my/edit' },
@@ -28,6 +29,7 @@ const Setting = () => {
   };
   return (
     <PageLayout>
+      <Seo title="설정" url="my/setting" />
       <Modal
         isModal={isLogoutModal}
         title="로그아웃"

--- a/src/pages/my/titles.tsx
+++ b/src/pages/my/titles.tsx
@@ -1,4 +1,5 @@
 import NavBar from '@components/common/NavBar';
+import Seo from '@components/common/Seo';
 import PageLayout from '@components/layout/PageLayout';
 import TitleInfo from '@components/title/TitleInfo';
 import TitleModal from '@components/title/TitleModal';
@@ -54,6 +55,7 @@ const Titles = () => {
 
   return (
     <PageLayout className="bg-white">
+      <Seo title="내 칭호" url="my/titles" />
       <NavBar centerTitle="내 칭호" isLeft={true} setIsInfo={setIsInfo} />
       {isInfo && <TitleInfo />}
       {isModal && <TitleModal setIsModal={setIsModal} title={modalTitle} />}

--- a/src/pages/notice.tsx
+++ b/src/pages/notice.tsx
@@ -4,6 +4,7 @@ import PageLayout from '@components/layout/PageLayout';
 import NoticeItem from '@components/notice/NoticeItem';
 import { noticeState } from '@recoil/noticeAtom';
 import { useRecoilState } from 'recoil';
+import Seo from '@components/common/Seo';
 
 const NOTICE_LIST = [
   { id: 1, title: '공지1', content: '공지1 관련 내용입니다.' },
@@ -17,6 +18,7 @@ const Notice = () => {
   }>(noticeState);
   return (
     <PageLayout>
+      <Seo title="공지사항" url="notice" />
       <NavBar isLeft={true} centerTitle="공지사항" />
       <NoticeContainer>
         {NOTICE_LIST.map(({ id, title, content }) => (

--- a/src/pages/shopDetail/index.tsx
+++ b/src/pages/shopDetail/index.tsx
@@ -17,6 +17,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { userState } from '@recoil/userAtom';
 import { modalState } from '@recoil/modalAtom';
 import ShopTitle from '@components/title/ShopTitle';
+import Seo from '@components/common/Seo';
 
 const ShopDetail = () => {
   const router = useRouter();
@@ -65,6 +66,7 @@ const ShopDetail = () => {
 
   return (
     <ShopLayout className="bg-white pt-[62px]">
+      <Seo title="지점" url="shopDetail" />
       {shopInfo && (
         <Scripts
           shopInfo={shopInfo}

--- a/src/pages/shopDetail/review.tsx
+++ b/src/pages/shopDetail/review.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
 import Button from '@components/common/Button';
 import usePostReview from '@hooks/mutations/usePostReview';
+import Seo from '@components/common/Seo';
 
 type ReviewForm = {
   star_rating?: number;
@@ -52,6 +53,7 @@ const Review = () => {
 
   return (
     <ShopLayout className="bg-white">
+      <Seo title="리뷰 작성" url="shopDetail/review" />
       <RatingContainer>
         <span className="pb-6 text-title2 font-semibold">이용 리뷰 작성</span>
         <div className="flex text-label2">

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -1,7 +1,0 @@
-import PageLayout from '@components/layout/PageLayout';
-
-const Terms = () => {
-  return <PageLayout>Terms</PageLayout>;
-};
-
-export default Terms;

--- a/src/pages/wish/index.tsx
+++ b/src/pages/wish/index.tsx
@@ -1,4 +1,5 @@
 import NavBar from '@components/common/NavBar';
+import Seo from '@components/common/Seo';
 import PageLayout from '@components/layout/PageLayout';
 import WishItem from '@components/wish/WishItem';
 import { useGetFavorite } from '@hooks/queries/useGetFavorite';
@@ -11,6 +12,7 @@ const Wish = () => {
   const { data: favorites } = useGetFavorite(curPos.lat, curPos.lng);
   return (
     <PageLayout>
+      <Seo title="찜" url="wish" />
       <NavBar leftTitle={'찜 목록'} favoritesNum={favorites?.length} />
       {favorites && favorites.length > 0 ? (
         <WishList>


### PR DESCRIPTION
## 🛠 작업 내용

close #193 

- `viewport meta tags should not be used in _document.js's <Head>. https://nextjs.org/docs/messages/no-document-viewport-meta` 메시지가 반복 출력되는 현상 수정을 위해 _document.tsx 파일 내에서 뷰포트 메타태그를 제거하고 공통적인 메타 태그를 추가했습니다.
- Seo 컴포넌트를 추가하여 동적으로 페이지마다 seo를 적용하도록 수정했습니다.
- 로그인 페이지에서 loading을 통해 렌더링을 구분해놓았던 것을 SplashLogin 컴포넌트에 loading을 props로 전달하여 1초 뒤 사라지도록 구현했습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
