### PR TITLE
refactor: #196/ 카카오톡 공유 시 기본 이미지 추가 & 내 리뷰 페이지 지점명 클릭시 지점 상세 페이지로 이동

### DIFF
--- a/src/pages/my/reviews/index.tsx
+++ b/src/pages/my/reviews/index.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import tw from 'tailwind-styled-components';
 import BrandTag from '@components/common/BrandTag';
 import Seo from '@components/common/Seo';
+import Link from 'next/link';
 
 const Reviews = () => {
   const router = useRouter();
@@ -46,8 +47,10 @@ const Reviews = () => {
                   <span className="text-caption1">
                     <BrandTag name={shop_info?.brand} />
                   </span>
-                  <div className="mb-4 text-title1 font-semibold">
-                    {shop_info.place_name}
+                  <div className="mb-4 cursor-pointer text-title1 font-semibold">
+                    <Link href={`/shopDetail?shopId=${shop_info.id}`}>
+                      {shop_info.place_name}
+                    </Link>
                   </div>
                 </div>
                 <BtnContainer>

--- a/src/pages/my/titles.tsx
+++ b/src/pages/my/titles.tsx
@@ -71,7 +71,7 @@ const Titles = () => {
           )}
           <TitleName>{titles?.main_member_title.name}</TitleName>
         </MainTitle>
-        <span className="mx-4 mt-[28px] h-[1px] w-[327px] bg-bg-primary" />
+        <span className="mx-4 my-10 h-[1px] w-[327px] bg-bg-primary" />
         <AllTitles>
           {titles?.member_titles.map(
             ({
@@ -160,11 +160,11 @@ const Titles = () => {
 export default Titles;
 
 const TitleContainer = tw.div`
-flex justify-center mt-[100px] flex-col mb-12
+flex justify-center mt-[68px] flex-col mb-[72px]
 `;
 
 const MainTitle = tw.div`
-flex flex-col items-center
+flex flex-col items-center pt-5
 `;
 
 const TitleName = tw.span`
@@ -172,7 +172,7 @@ mt-4 text-label1 font-semibold
 `;
 
 const AllTitles = tw.div`
-grid grid-cols-3 place-items-center mt-[49px] gap-y-10
+grid grid-cols-3 place-items-center gap-y-10
 `;
 
 const TitleBox = tw.div`

--- a/src/pages/shopDetail/index.tsx
+++ b/src/pages/shopDetail/index.tsx
@@ -49,7 +49,7 @@ const ShopDetail = () => {
         addressTitle: place_name,
         content: {
           title: place_name,
-          imageUrl: '',
+          imageUrl: 'https://d18tllc1sxg8cp.cloudfront.net/logo/main_logo.png',
           link: {
             mobileWebUrl: `https://photosmap.vercel.app/shopDetail?shopId=${shopId}`,
             webUrl: `https://photosmap.vercel.app/shopDetail?shopId=${shopId}`,
@@ -108,15 +108,11 @@ const ShopDetail = () => {
           <div>{shopInfo?.distance.replaceAll('"', '')}</div>
         </ShopRate>
         <ShopEventBox>
-          <ShopEvent
-            onClick={() => {
-              if (shopInfo && shopInfo.place_url) {
-                router.push(shopInfo.place_url);
-              }
-            }}
-          >
-            <Image src={'/svg/map.svg'} width={18} height={18} alt="지도" />
-            <div className="pl-[2px]">카카오맵 보기</div>
+          <ShopEvent>
+            <a className="flex" href={shopInfo?.place_url} target="_blank">
+              <Image src={'/svg/map.svg'} width={18} height={18} alt="지도" />
+              <div className="pl-[2px]">카카오맵 보기</div>
+            </a>
           </ShopEvent>
           <ShopEvent
             onClick={() => {


### PR DESCRIPTION
## 🛠 작업 내용

close #196 

- 카카오톡 공유 시 서비스 메인 이미지가 나오도록 수정했습니다.
- 내 리뷰 페이지에서 지점명 클릭시 해당 지점 상세 페이지로 이동하도록 수정했습니다.
- 내 칭호 페이지 하단 마진을 추가했습니다.

## 📸 스크린샷 or GIF

<!--스크린샷 또는 GIF를 첨부해주세요.-->
